### PR TITLE
Apply toms feedback

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,15 +1,4 @@
-# redis-operator
-
-## Description
-
-The [Redis](https://www.redis.io/) operator provides in-memory data structure 
-store, used as a database, cache, and message broker. This repository contains a
-[Juju](https://jaas.ai/) Charm for deploying Redis on Kubernetes
-clusters.
-
-This charm does not support Redis clustering capabilities.
-
-## Setup, build and deploy
+# Setup, build and deploy
 
 A typical setup using [snaps](https://snapcraft.io/), for deployments
 to a [microk8s](https://microk8s.io/) cluster can be done using the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,112 @@
+# redis-operator
+
+## Description
+
+The [Redis](https://www.redis.io/) operator provides in-memory data structure 
+store, used as a database, cache, and message broker. This repository contains a
+[Juju](https://jaas.ai/) Charm for deploying Redis on Kubernetes
+clusters.
+
+This charm does not support Redis clustering capabilities.
+
+## Setup, build and deploy
+
+A typical setup using [snaps](https://snapcraft.io/), for deployments
+to a [microk8s](https://microk8s.io/) cluster can be done using the
+following commands.
+
+Install the dependencies:
+
+    sudo snap install juju --classic
+    sudo snap install microk8s --classic
+    microk8s.enable dns storage
+    
+Create a controller named `micro` into the cloud `microk8s`:
+  
+    juju bootstrap microk8s micro
+
+In Juju, you interact with the client (the `juju` command on your local machine). 
+It connects to a controller. The controller is hosted on a cloud and controls models.
+
+    juju add-model redis-model
+
+Then you build and deploy this charm into the model you just created:
+    
+    charmcraft build
+    juju deploy ./redis.charm --resource redis-image=redis:6.0
+
+Once Redis starts up it will be running on its default port, 6379. 
+To check it you run:
+
+    juju status
+
+to discover the IP Redis is running behind. The output will have lines like:
+
+    Unit       Workload    Agent  Address       Ports     Message
+    redis/20   active      idle   10.1.168.69   6379/TCP  Pod is ready.
+
+Then, from your local machine, you can:
+
+    redis-cli -h 10.1.168.69 -p 3000
+
+Another option is to port-forward the Redis pod or service port from k8s to a local port.
+For example, forwarding a node's port
+
+    microk8s.kubectl --namespace=redis-model port-forward pod/redis-8485b69dfd-6hgvj 6379:6379
+
+However, it is simpler to forward the service port as it will abstract the node name behind it:
+
+    microk8s.kubectl --namespace=redis-model port-forward service/redis 6379:6379
+
+Then you can simply:
+
+    redis-cli
+
+From a k8s non-charmed scenario Redis will be exposed as `Service` named `redis` on the default
+port `6379`.
+
+## Developing
+
+The charm is based on the [operator framework](https://github.com/canonical/operator/). Create and activate 
+a virtualenv with the development requirements:
+
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements-dev.txt
+
+In order to check the result of a modification, rebuild and upgrade the charm:
+
+    # Consider now that you are inside redis-operator directory.
+    charmcraft build
+    juju upgrade-charm --path="./redis.charm" redis --force-units
+
+Or you can clean up things on different levels, application, model, and controller:
+
+    juju remove-application redis --force --no-wait
+    juju destroy-model redis-model --destroy-storage --force --no-wait
+    juju destroy-controller micro --destroy-all-models
+
+## Debugging
+
+In order to enable `TRACE` level at the unit to make everything shows:
+    
+    juju model-config logging-config="<root>=WARNING;unit=TRACE"
+
+To show the logs for a specific mode:
+    
+    juju debug-log -m redis-model
+
+To show the logs for all the units in the model:
+
+    microk8s.kubectl get all --namespace=redis-model
+
+To see the logs for a specific pod:
+    
+    microk8s.kubectl --namespace=redis-model logs redis-operator-0
+
+## Testing
+
+The Python operator framework includes a very nice harness for testing
+operator behaviour without full deployment. Just `run_tests`:
+
+    ./run_tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@ It connects to a controller. The controller is hosted on a cloud and controls mo
 Then you build and deploy this charm into the model you just created:
     
     charmcraft build
-    juju deploy ./redis.charm --resource redis-image=redis:6.0
+    juju deploy ./redis.charm --resource redis-image=ubuntu/redis
 
 Once Redis starts up it will be running on its default port, 6379. 
 To check it you run:
@@ -36,7 +36,7 @@ to discover the IP Redis is running behind. The output will have lines like:
 
 Then, from your local machine, you can:
 
-    redis-cli -h 10.1.168.69 -p 3000
+    redis-cli -h 10.1.168.69 -p 6379
 
 Another option is to port-forward the Redis pod or service port from k8s to a local port.
 For example, forwarding a node's port

--- a/README.md
+++ b/README.md
@@ -1,112 +1,18 @@
-# redis-operator
+# Redis Operator
 
-## Description
+A Juju charm deploying and managing Redis on Kubernetes.
+
+# Overview
 
 The [Redis](https://www.redis.io/) operator provides in-memory data structure 
 store, used as a database, cache, and message broker. This repository contains a
 [Juju](https://jaas.ai/) Charm for deploying Redis on Kubernetes
 clusters.
 
-This charm does not support Redis clustering capabilities.
+This charm is in development, and it supports simple Redis topology. Although multiple
+units are allowed, nor replication nor clustering are supported for the moment. You can
+track the development in [this](https://github.com/canonical/redis-operator/issues/2) 
+and [this](https://github.com/canonical/redis-operator/issues/3) issues, respectively.
 
-## Setup, build and deploy
+# Usage
 
-A typical setup using [snaps](https://snapcraft.io/), for deployments
-to a [microk8s](https://microk8s.io/) cluster can be done using the
-following commands.
-
-Install the dependencies:
-
-    sudo snap install juju --classic
-    sudo snap install microk8s --classic
-    microk8s.enable dns storage
-    
-Create a controller named `micro` into the cloud `microk8s`:
-  
-    juju bootstrap microk8s micro
-
-In Juju, you interact with the client (the `juju` command on your local machine). 
-It connects to a controller. The controller is hosted on a cloud and controls models.
-
-    juju add-model redis-model
-
-Then you build and deploy this charm into the model you just created:
-    
-    charmcraft build
-    juju deploy ./redis.charm --resource redis-image=redis:6.0
-
-Once Redis starts up it will be running on its default port, 6379. 
-To check it you run:
-
-    juju status
-
-to discover the IP Redis is running behind. The output will have lines like:
-
-    Unit       Workload    Agent  Address       Ports     Message
-    redis/20   active      idle   10.1.168.69   6379/TCP  Pod is ready.
-
-Then, from your local machine, you can:
-
-    redis-cli -h 10.1.168.69 -p 3000
-
-Another option is to port-forward the Redis pod or service port from k8s to a local port.
-For example, forwarding a node's port
-
-    microk8s.kubectl --namespace=redis-model port-forward pod/redis-8485b69dfd-6hgvj 6379:6379
-
-However, it is simpler to forward the service port as it will abstract the node name behind it:
-
-    microk8s.kubectl --namespace=redis-model port-forward service/redis 6379:6379
-
-Then you can simply:
-
-    redis-cli
-
-From a k8s non-charmed scenario Redis will be exposed as `Service` named `redis` on the default
-port `6379`.
-
-## Developing
-
-The charm is based on the [operator framework](https://github.com/canonical/operator/). Create and activate 
-a virtualenv with the development requirements:
-
-    virtualenv -p python3 venv
-    source venv/bin/activate
-    pip install -r requirements-dev.txt
-
-In order to check the result of a modification, rebuild and upgrade the charm:
-
-    # Consider now that you are inside redis-operator directory.
-    charmcraft build
-    juju upgrade-charm --path="./redis.charm" redis --force-units
-
-Or you can clean up things on different levels, application, model, and controller:
-
-    juju remove-application redis --force --no-wait
-    juju destroy-model redis-model --destroy-storage --force --no-wait
-    juju destroy-controller micro --destroy-all-models
-
-## Debugging
-
-In order to enable `TRACE` level at the unit to make everything shows:
-    
-    juju model-config logging-config="<root>=WARNING;unit=TRACE"
-
-To show the logs for a specific mode:
-    
-    juju debug-log -m redis-model
-
-To show the logs for all the units in the model:
-
-    microk8s.kubectl get all --namespace=redis-model
-
-To see the logs for a specific pod:
-    
-    microk8s.kubectl --namespace=redis-model logs redis-operator-0
-
-## Testing
-
-The Python operator framework includes a very nice harness for testing
-operator behaviour without full deployment. Just `run_tests`:
-
-    ./run_tests

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ store, used as a database, cache, and message broker. This repository contains a
 [Juju](https://jaas.ai/) Charm for deploying Redis on Kubernetes
 clusters.
 
-This charm is in development, and it supports simple Redis topology. Although multiple
-units are allowed, nor replication nor clustering are supported for the moment. You can
+This charm is in development, and it supports a simple Redis topology. Although multiple
+units are allowed, replication and clustering are not supported for the moment. You can
 track the development in [this](https://github.com/canonical/redis-operator/issues/2) 
 and [this](https://github.com/canonical/redis-operator/issues/3) issues, respectively.
 

--- a/README.md
+++ b/README.md
@@ -16,4 +16,21 @@ and [this](https://github.com/canonical/redis-operator/issues/3) issues, respect
 
 # Usage
 
-    juju deploy redis
+While this charm is not in the charmstore/charmhub you can build and deploy it locally by:
+
+    charmcraft build
+    juju deploy ./redis.charm --resource redis-image=ubuntu/redis
+
+Once Redis starts up it will be running on its default port, 6379. 
+To check it you run:
+
+    juju status
+
+to discover the IP Redis is running behind. The output will have lines like:
+
+    Unit       Workload    Agent  Address       Ports     Message
+    redis/20   active      idle   10.1.168.69   6379/TCP  Pod is ready.
+
+Then, from your local machine, you can:
+
+    redis-cli -h 10.1.168.69 -p 6379

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ and [this](https://github.com/canonical/redis-operator/issues/3) issues, respect
 
 # Usage
 
+    juju deploy redis

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,8 +32,8 @@ summary: >
   automatic partitioning with Redis Cluster.
 
   This charm supports Redis 5 in Kubernetes environments, using k8s services
-  for load balancing. This supports simple Redis topology. Although multiple
-  units are allowed, nor replication nor clustering are supported for the moment.
+  for load balancing. This supports a simple Redis topology. Although multiple
+  units are allowed, replication and clustering are not supported for the moment.
 maintainers:
   - Eduardo Mucelli R. Oliveira <eduardo.mucelli@canonical.com>
 min-juju-version: 2.8.7

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,8 @@ display-name: Redis
 description: >
   Redis charm for Kubernetes deployments.
 tags:
-  - databases
+  - database
+  - storage
   - kubernetes
   - redis
 summary: >
@@ -30,8 +31,9 @@ summary: >
   of on-disk persistence, and provides high availability via Redis Sentinel and
   automatic partitioning with Redis Cluster.
 
-  This charm supports Redis 6 in Kubernetes environments, using k8s services
-  for load balancing. This charm does not support Redis clustering capabilities.
+  This charm supports Redis 5 in Kubernetes environments, using k8s services
+  for load balancing. This supports simple Redis topology. Although multiple
+  units are allowed, nor replication nor clustering are supported for the moment.
 maintainers:
   - Eduardo Mucelli R. Oliveira <eduardo.mucelli@canonical.com>
 min-juju-version: 2.8.7
@@ -41,6 +43,9 @@ deployment:
   min-version: '1.16'
   type: stateful
   service: loadbalancer
+provides:
+  datastore:
+    interface: redis
 storage:
   database:
     type: filesystem
@@ -48,5 +53,5 @@ storage:
 resources:
   redis-image:
     type: oci-image
-    description: upstream docker image for redis
-    upstream-source: 'redis:6.0'
+    description: ubuntu lts docker image for redis
+    upstream-source: 'ubuntu/redis'

--- a/src/charm.py
+++ b/src/charm.py
@@ -149,8 +149,15 @@ class RedisCharm(CharmBase):
 
     @log_event_handler
     def relation_changed(self, event):
-        """This event handler pass the host and port to the remote unit
+        """This event handler pass the host and port to the remote unit.
+         Any Redis client is provided with the following information
+        - Redis host
+        - Redis port
+
+        Using this information a client can establish a connection with
+        Redis, for instances using the redis Python library.
         """
+
         if not self.unit.is_leader():
             logger.debug("Relation changes ignored by non-leader")
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ class RedisCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self.configure_pod)
         self.framework.observe(self.on.upgrade_charm, self.configure_pod)
         self.framework.observe(self.on.update_status, self.update_status)
+        self.framework.observe(self.on["datastore"].relation_changed, self.relation_changed)
 
     @log_event_handler
     def on_start(self, event):
@@ -145,6 +146,17 @@ class RedisCharm(CharmBase):
             return
 
         self.set_ready_status()
+
+    @log_event_handler
+    def relation_changed(self, event):
+        """This event handler pass the host and port to the remote unit
+        """
+        if not self.unit.is_leader():
+            logger.debug("Relation changes ignored by non-leader")
+            return
+
+        event.relation.data[self.unit]['host'] = self.app.name
+        event.relation.data[self.unit]['port'] = str(DEFAULT_PORT)
 
     def set_ready_status(self):
         logger.debug('Pod is ready.')

--- a/src/charm.py
+++ b/src/charm.py
@@ -162,8 +162,18 @@ class RedisCharm(CharmBase):
             logger.debug("Relation changes ignored by non-leader")
             return
 
-        event.relation.data[self.unit]['host'] = self.app.name
+        event.relation.data[self.unit]['hostname'] = str(self.bind_address(event))
         event.relation.data[self.unit]['port'] = str(DEFAULT_PORT)
+        # The reactive Redis charm exposes also 'password'. When tackling
+        # https://github.com/canonical/redis-operator/issues/7 add 'password'
+        # field so that it matches the exposed interface information from it.
+        # event.relation.data[self.unit]['password'] = ''
+
+    def bind_address(self, event):
+        relation = self.model.get_relation(event.relation.name, event.relation.id)
+        if address := self.model.get_binding(relation).network.bind_address:
+            return address
+        return self.app.name
 
     def set_ready_status(self):
         logger.debug('Pod is ready.')

--- a/src/pod_spec.py
+++ b/src/pod_spec.py
@@ -52,6 +52,7 @@ class PodSpecBuilder:
                 "imagePullPolicy": "Always",
                 "ports": self._build_port_spec(),
                 # "volumeConfig": vol_config,
+                "envConfig": self._build_env_config(),
                 "kubernetes": {
                     "readinessProbe": self._build_readiness_spec(),
                     "livenessProbe": self._build_liveness_spec()
@@ -61,6 +62,11 @@ class PodSpecBuilder:
         }
 
         return spec
+
+    def _build_env_config(self):
+        return {
+            "ALLOW_EMPTY_PASSWORD": "yes"
+        }
 
     def _build_liveness_spec(self) -> Dict:
         return {

--- a/src/pod_spec.py
+++ b/src/pod_spec.py
@@ -65,6 +65,7 @@ class PodSpecBuilder:
 
     def _build_env_config(self):
         return {
+            # https://github.com/canonical/redis-operator/issues/7
             "ALLOW_EMPTY_PASSWORD": "yes"
         }
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -30,7 +30,7 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(RedisCharm)
         self.addCleanup(self.harness.cleanup)
         redis_resource = {
-            "registrypath": "redis:6.0"
+            "registrypath": "ubuntu/redis"
         }
         self.harness.add_oci_resource("redis-image", redis_resource)
         self.harness.begin()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -160,16 +160,19 @@ class TestCharm(unittest.TestCase):
             ActiveStatus()
         )
 
-    def test_on_relation_changed_status_when_unit_is_leader(self):
+    @mock.patch.object(RedisCharm, 'bind_address')
+    def test_on_relation_changed_status_when_unit_is_leader(self, bind_address):
         # Given
         self.harness.set_leader(True)
+        bind_address.return_value = '10.2.1.5'
+
         rel_id = self.harness.add_relation('datastore', 'wordpress')
         self.harness.add_relation_unit(rel_id, 'wordpress/0')
         # When
-        self.harness.update_relation_data(rel_id,'wordpress/0', {})
+        self.harness.update_relation_data(rel_id, 'wordpress/0', {})
         rel_data = self.harness.get_relation_data(
             rel_id, self.harness.charm.unit.name
         )
         # Then
-        self.assertEqual(rel_data.get('host'), 'redis')
+        self.assertEqual(rel_data.get('hostname'), '10.2.1.5')
         self.assertEqual(rel_data.get('port'), '6379')


### PR DESCRIPTION
This PR applies the changes from the feedback given by @mthaddon. I have 

* Moved the whole techie part of the documentation to a DEVELOPMENT.md (this also will be present in the discourse-based documentation)
* Simplified the README.md -- still lacks expanding the usage part
* Replace the upstream image with the `ubuntu/redis` image
   - This required changing the spec as the underlying image explicitly asks for empty password
* I have qualified the lack of replication/clustering and added the respective issues in this repo.

I am still not sure about the relation part. I have left a comment.