### PR TITLE
No need to check state of spec before applying pod-spec-set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.charm
 build/
 __pycache__
+.coverage
 .idea

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,8 +55,6 @@ class RedisCharm(CharmBase):
         super().__init__(*args)
         logger.debug('Initializing charm')
 
-        self.state.set_default(pod_spec=None)
-
         self.redis = RedisClient(host=self.model.app.name, port=DEFAULT_PORT)
         self.image = OCIImageResource(self, "redis-image")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -118,14 +118,9 @@ class RedisCharm(CharmBase):
         spec = builder.build_pod_spec()
         logger.debug("Pod spec: \n{}".format(yaml.dump(spec)))
 
-        # Update pod spec if the generated one is different
-        # from the one previously applied.
-        if self.state.pod_spec == spec:
-            logger.debug("Discarding pod spec because it has not changed.")
-        else:
-            logger.debug("Applying new pod spec.")
-            self.model.pod.set_spec(spec)
-            self.state.pod_spec = spec
+        # Applying pod spec. If the spec hasn't changed, this has no effect.
+        logger.debug("Applying pod spec.")
+        self.model.pod.set_spec(spec)
 
         if not self.redis.is_ready():
             self.unit.status = WaitingStatus(WAITING_FOR_REDIS_MSG)

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -106,7 +106,6 @@ class TestCharm(unittest.TestCase):
         # When
         self.harness.charm.on.config_changed.emit()
         # Then
-        self.assertIsNotNone(self.harness.charm.state.pod_spec)
         self.assertEqual(
             self.harness.charm.unit.status,
             ActiveStatus()


### PR DESCRIPTION
There's no need to check the state of the spec object running set_spec - Juju will only apply this if something has changed.