### PR TITLE
Avoid polluting test output with logs and assert expected logging

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -55,7 +55,11 @@ class TestClient(unittest.TestCase):
         mock_redis.side_effect = redis.exceptions.ConnectionError()
 
         # When
-        is_ready = self.client.is_ready()
+        with self.assertLogs(level="WARNING") as logger:
+            is_ready = self.client.is_ready()
 
-        # Then
-        self.assertFalse(is_ready)
+            # Then
+            self.assertFalse(is_ready)
+            self.assertEqual(
+                logger.output,
+                ["WARNING:client:[redis-operator:client] Unable to connect to Redis: "])


### PR DESCRIPTION
Avoid polluting test output with logs and assert expected logging in test_when_redis_fails_to_connect_then_redis_is_not_ready