### PR TITLE
Add link to discourse-based documentation that will appear on charmhub

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,7 @@
 
 name: redis-k8s
 display-name: Redis
+docs: https://discourse.charmhub.io/t/redis-docs-index/4571
 description: >
   Redis charm for Kubernetes deployments.
 tags:


### PR DESCRIPTION
Add link to discourse-based documentation that will appear on charmhub