### PR TITLE
DPE-116 Add initial admin password

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -54,3 +54,7 @@ resources:
     type: oci-image
     description: ubuntu lts docker image for redis
     upstream: ubuntu/redis
+
+peers:
+  redis-peers:
+    interface: redis-peers

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-ops~=1.2.0
+ops~=1.3.0
 redis~=3.5.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,6 +33,8 @@ REDIS_PORT = 6379
 WAITING_MESSAGE = "Waiting for Redis..."
 CONFIG_PATH = "/etc/redis/"
 PEER = "redis-peers"
+PEER_PASSWORD_KEY = "redis-password"
+
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +73,13 @@ class RedisK8sCharm(CharmBase):
         will be stored on the peer relation databag.
         """
         peer_data = self._peers.data[self.app]
-        redis_password = peer_data.get("redis-password", None)
+        redis_password = peer_data.get(PEER_PASSWORD_KEY, None)
 
         if redis_password is None:
-            self._peers.data[self.app]["redis-password"] = self._generate_password()
+            self._peers.data[self.app][PEER_PASSWORD_KEY] = self._generate_password()
 
             # TODO: remove this once the action to retrieve the password is implemented
-            logger.info("REDIS PASSWORD: {}".format(peer_data.get("redis-password", None)))
+            logger.info("REDIS PASSWORD: {}".format(peer_data.get(PEER_PASSWORD_KEY, None)))
 
     def _config_changed(self, event: EventBase) -> None:
         """Handle config_changed event.
@@ -208,7 +210,7 @@ class RedisK8sCharm(CharmBase):
             String with the password
         """
         data = self._peers.data[self.app]
-        return data.get("redis-password", "")
+        return data.get(PEER_PASSWORD_KEY, "")
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -161,6 +161,7 @@ class RedisK8sCharm(CharmBase):
         Returns:
             An `ops.model.Relation` object representing the peer relation.
         """
+        return self.model.get_relation(PEER)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,14 +72,17 @@ class RedisK8sCharm(CharmBase):
         If no password exists, a new one will be created for accessing Redis. This password
         will be stored on the peer relation databag.
         """
-        peer_data = self._peers.data[self.app]
-        redis_password = peer_data.get(PEER_PASSWORD_KEY, None)
+        redis_password = self._get_password()
 
-        if redis_password is None:
+        if not redis_password:
             self._peers.data[self.app][PEER_PASSWORD_KEY] = self._generate_password()
 
             # TODO: remove this once the action to retrieve the password is implemented
-            logger.info("REDIS PASSWORD: {}".format(peer_data.get(PEER_PASSWORD_KEY, None)))
+            logger.info(
+                "REDIS PASSWORD: {}".format(
+                    self._peers.data[self.app].get(PEER_PASSWORD_KEY, None)
+                )
+            )
 
     def _config_changed(self, event: EventBase) -> None:
         """Handle config_changed event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,8 +22,8 @@ from typing import Optional
 from charms.redis_k8s.v0.redis import RedisProvides
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, WaitingStatus, Relation
-from ops.pebble import Layer, ConnectionError
+from ops.model import ActiveStatus, Relation, WaitingStatus
+from ops.pebble import Layer
 from redis import Redis
 from redis.exceptions import RedisError
 
@@ -90,7 +90,7 @@ class RedisK8sCharm(CharmBase):
         to the new one, Pebble is updated. If not, nothing needs to be done.
         """
         container = self.unit.get_container("redis")
-        
+
         if not container.can_connect():
             self.unit.status = WaitingStatus("Waiting for Pebble in workload container")
             return
@@ -113,7 +113,7 @@ class RedisK8sCharm(CharmBase):
 
     def _redis_layer(self) -> Layer:
         """Create the Pebble configuration layer for Redis.
-        
+
         Returns:
             A `ops.pebble.Layer` object with the current layer options
         """

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
 from unittest import TestCase, mock
 
 from charms.redis_k8s.v0.redis import RedisProvides
@@ -167,13 +166,15 @@ class TestCharm(TestCase):
 
     def test_password_on_leader_elected(self):
         # Assert that there is no password in the peer relation.
-        self.assertIsNone(self.harness.charm._peers.data[self.harness.charm.app].get(
-            "redis-password", None)
+        self.assertIsNone(
+            self.harness.charm._peers.data[self.harness.charm.app].get("redis-password", None)
         )
 
         # Check that a new password was generated on leader election.
         self.harness.set_leader()
-        admin_password = self.harness.charm._peers.data[self.harness.charm.app].get("redis-password", None)
+        admin_password = self.harness.charm._peers.data[self.harness.charm.app].get(
+            "redis-password", None
+        )
         self.assertIsNotNone(admin_password)
 
         # Trigger a new leader election and check that the password is still the same.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -166,22 +166,18 @@ class TestCharm(TestCase):
 
     def test_password_on_leader_elected(self):
         # Assert that there is no password in the peer relation.
-        self.assertIsNone(
-            self.harness.charm._peers.data[self.harness.charm.app].get("redis-password", None)
-        )
+        self.assertFalse(self.harness.charm._get_password())
 
         # Check that a new password was generated on leader election.
         self.harness.set_leader()
-        admin_password = self.harness.charm._peers.data[self.harness.charm.app].get(
-            "redis-password", None
-        )
-        self.assertIsNotNone(admin_password)
+        admin_password = self.harness.charm._get_password()
+        self.assertTrue(admin_password)
 
         # Trigger a new leader election and check that the password is still the same.
         self.harness.set_leader(False)
         self.harness.set_leader()
         self.assertEqual(
-            self.harness.charm._peers.data[self.harness.charm.app].get("redis-password", None),
+            self.harness.charm._get_password(),
             admin_password,
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,14 +16,8 @@
 from unittest import TestCase, mock
 
 from charms.redis_k8s.v0.redis import RedisProvides
-from ops.model import (
-    ActiveStatus,
-    Container,
-    MaintenanceStatus,
-    UnknownStatus,
-    WaitingStatus,
-)
-from ops.pebble import ConnectionError, ServiceInfo
+from ops.model import ActiveStatus, Container, UnknownStatus, WaitingStatus
+from ops.pebble import ServiceInfo
 from ops.testing import Harness
 from redis import Redis
 from redis.exceptions import RedisError
@@ -140,9 +134,10 @@ class TestCharm(TestCase):
         self.harness.update_config()
         mock_container.add_layer.assert_not_called()
         mock_container.restart.assert_not_called()
-        self.assertEqual(self.harness.charm.unit.status, WaitingStatus(
-            "Waiting for Pebble in workload container"
-            ))
+        self.assertEqual(
+            self.harness.charm.unit.status,
+            WaitingStatus("Waiting for Pebble in workload container"),
+        )
         self.assertEqual(self.harness.charm.app.status, UnknownStatus())
         self.assertEqual(self.harness.get_workload_version(), None)
         # TODO - test for the event being deferred


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
This PR address JIRA ticket [DPE-116](https://warthogs.atlassian.net/browse/DPE-116).
By default,  databases should be deployed with an initial admin password, increasing the security of the system.
 
### Solution
<!-- A summary of the solution addressing the above problem -->
A randomly generated password, 16 characters long, is generated on the leader unit, if no previous password existed.

The peer relation databag is used to store the password. Although the current status of the charm only deploys Redis as a standalone replica, with this solution the new changes will make use of the existing peer relation storage system. Using the peer databag will also help in maintaining the same password during scaling up/down of the application.

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->
The password is being injected into the database using the [ubuntu/redis](https://hub.docker.com/r/ubuntu/redis) environment parameters. The entrypoint script to the container updates the Redis config file to reflect the password change. Because of this, there is no need (yet) to use a config template.

### Release Notes
<!-- A digestable summary of the change in this PR -->
The Pebble layer logic has been refactored to ease future updates to the code.

- `requirements.txt`: `ops` has been updated to 1.3.0 to use of `container.can_connect()` method
- `src/charm.py`
   - `config_changed()`: this method has been simplified, creating two more with specific logic: `_redis_layer()` that returns an updated Pebble layer, and `_update_layer()` tasked with updating Pebble if needed.
   - The peer relation databag now stores a password.
   - Some helper charm methods have been added; `_generate_password()`, `_get_password()` and a property for the peer relation `_peers()`

### PS
Integration tests will be fixed on a next PR when an action to get the current password is added.