### PR TITLE
DPE-117 Add password action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -15,3 +15,6 @@
 
 check-service:
   description: Check if the redis service is up
+
+get-initial-admin-password:
+  description: Returns the randomly generated password at charm deployment

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,7 @@ import string
 from typing import Optional
 
 from charms.redis_k8s.v0.redis import RedisProvides
-from ops.charm import CharmBase
+from ops.charm import ActionEvent, CharmBase
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, Relation, WaitingStatus
@@ -58,6 +58,9 @@ class RedisK8sCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._update_status)
 
         self.framework.observe(self.on.check_service_action, self.check_service)
+        self.framework.observe(
+            self.on.get_initial_admin_password_action, self._get_password_action
+        )
 
     def _redis_pebble_ready(self, _) -> None:
         """Handle the pebble_ready event.
@@ -186,6 +189,13 @@ class RedisK8sCharm(CharmBase):
         else:
             results["result"] = "Service is not running"
         event.set_results(results)
+
+    def _get_password_action(self, event: ActionEvent) -> None:
+        """Handle the get_initial_admin_password event.
+
+        Sets the result of the action with the admin password for Redis.
+        """
+        event.set_results({"redis-password": self._get_password()})
 
     @property
     def _peers(self) -> Optional[Relation]:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -56,6 +56,7 @@ async def test_application_is_up(ops_test: OpsTest):
     # Use action to get admin password
     logger.info("calling action to retrieve password")
     password = await get_password(ops_test)
+    logger.info("retrieved password for %s: %s", APP_NAME, password)
 
     cli = Redis(address, password=password)
 
@@ -105,6 +106,7 @@ async def test_same_password_after_scaling(ops_test: OpsTest):
     logger.info("calling action to retrieve password")
     after_pw = await get_password(ops_test)
 
+    logger.info("before scaling password: %s - after scaling password: %s", before_pw, after_pw)
     assert before_pw == after_pw
 
     status = await ops_test.model.get_status()  # noqa: F821


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
This PR address JIRA ticket [DPE-117](https://warthogs.atlassian.net/browse/DPE-117).
When deploying the database with a default password, an action should be provided to retrieve that password.
 
### Solution
<!-- A summary of the solution addressing the above problem -->
The charm will implement an action to return the initial password.

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->
This charm stores the password on the peer relation databag.

### Release Notes
<!-- A digestable summary of the change in this PR -->

- `actions.yaml`: new action created; `get-initial-admin-password`
- `src/charm.py`
   - `_get_password_action()`:  Handler for the action. Will create a result with the key `redis-password`.
- `tests/integration/test_charm.py`
   - `test_application_is_up()`: now uses the password
   - `test_database_with_no_password()`: check that the database is not accessible without a password
   - `test_same_password_after_scaling()`: scale down and up the application to test that the password remains the same