### PR TITLE
Update charm to support `redis` relation interface

### DIFF
--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -44,7 +44,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -93,8 +93,15 @@ class RedisProvides(Object):
         """A class implementing the redis provides relation."""
         super().__init__(charm, "redis")
         self.framework.observe(charm.on.redis_relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on.redis_relation_created, self._on_relation_created)
         self._port = port
+        self.charm = charm
 
+    def _on_relation_created(self, _):
+        """Handle the relation created event."""
+        self.charm._peers.data[self.charm.app]["enable-password"] = "false"
+        self.charm._update_layer()
+    
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
         if not self.model.unit.is_leader():

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -99,6 +99,8 @@ class RedisProvides(Object):
 
     def _on_relation_created(self, _):
         """Handle the relation created event."""
+        # TODO: Update warning to point to the new interface once it is created
+        logger.warning("DEPRECATION WARNING - `redis` interface is a legacy interface.")
         self.charm._peers.data[self.charm.app]["enable-password"] = "false"
         self.charm._update_layer()
     

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -101,8 +101,9 @@ class RedisProvides(Object):
         """Handle the relation created event."""
         # TODO: Update warning to point to the new interface once it is created
         logger.warning("DEPRECATION WARNING - `redis` interface is a legacy interface.")
-        self.charm._peers.data[self.charm.app]["enable-password"] = "false"
-        self.charm._update_layer()
+        if self.charm.unit.is_leader():
+            self.charm._peers.data[self.charm.app]["enable-password"] = "false"
+            self.charm._update_layer()
     
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,9 +143,7 @@ class RedisK8sCharm(CharmBase):
         # have a password.
         new_layer = self._redis_layer()
         if self._peers.data[self.app].get("enable-password", "true") == "false":
-            logger.warning(
-                "DEPRECATION WARNING - charm configured with password off"
-            )
+            logger.warning("DEPRECATION WARNING - charm configured with password off")
             env = new_layer.services["redis"].environment
             env["ALLOW_EMPTY_PASSWORD"] = "yes"
             if "REDIS_PASSWORD" in env:

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,7 +143,9 @@ class RedisK8sCharm(CharmBase):
         # have a password.
         new_layer = self._redis_layer()
         if self._peers.data[self.app].get("enable-password", "true") == "false":
-            logger.warning("DEPRECATION WARNING - charm configured with password off")
+            logger.warning(
+                "DEPRECATION WARNING - password off, this will be removed on later versions"
+            )
             env = new_layer.services["redis"].environment
             env["ALLOW_EMPTY_PASSWORD"] = "yes"
             if "REDIS_PASSWORD" in env:

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,7 +144,7 @@ class RedisK8sCharm(CharmBase):
         new_layer = self._redis_layer()
         if self._peers.data[self.app].get("enable-password", "true") == "false":
             logger.warning(
-                "DEPRECATION WARNING - password toggle off will not be supported in the future"
+                "DEPRECATION WARNING - charm configured with password off"
             )
             env = new_layer.services["redis"].environment
             env["ALLOW_EMPTY_PASSWORD"] = "yes"

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,6 +59,7 @@ class RedisK8sCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._config_changed)
         self.framework.observe(self.on.upgrade_charm, self._upgrade_charm)
         self.framework.observe(self.on.update_status, self._update_status)
+        self.framework.observe(self.on.redis_peers_relation_changed, self._peer_relation_changed)
 
         self.framework.observe(self.on.check_service_action, self.check_service)
         self.framework.observe(
@@ -119,6 +120,12 @@ class RedisK8sCharm(CharmBase):
         """
         logger.info("Beginning update_status")
         self._redis_check()
+
+    def _peer_relation_changed(self, _):
+        """Handle peer_relation_changed."""
+        # NOTE: Updates on legacy `redis` relation only (DEPRECATE)
+        if self._peers.data[self.app].get("enable-password", "true") == "false":
+            self._update_layer()
 
     def _update_layer(self) -> None:
         """Update the Pebble layer.

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,7 @@ class RedisK8sCharm(CharmBase):
         # Create the new config layer
         new_layer = self._redis_layer()
 
-        # NOTE: This block is to allow the lecagy `redis` relation interface to work
+        # NOTE: This block is to allow the legacy `redis` relation interface to work
         # with charms still using it. Charms using the relation don't expect Redis to
         # have a password.
         new_layer = self._redis_layer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -148,7 +148,8 @@ class RedisK8sCharm(CharmBase):
             )
             env = new_layer.services["redis"].environment
             env["ALLOW_EMPTY_PASSWORD"] = "yes"
-            if "REDIS_PASSWORD" in env: del env["REDIS_PASSWORD"]
+            if "REDIS_PASSWORD" in env:
+                del env["REDIS_PASSWORD"]
 
         # Update the Pebble configuration Layer
         if current_layer.services != new_layer.services:

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -19,14 +19,13 @@ def redis_client(password_enabled: str, password: str, ssl=False, storage_path="
     Returns:
         Redis class with the connection
     """
-    redis = Redis()
-
     # NOTE: This check will become deprecated in the future
     if password_enabled == "true":
         redis = Redis(password=password)
-
-    if ssl:
+    elif ssl:
         ca_path = f"{storage_path}/ca.crt"
         redis = Redis(password=password, ssl=ssl, ssl_ca_certs=ca_path)
+    else:
+        redis = Redis()
 
     return redis

--- a/src/redis_client.py
+++ b/src/redis_client.py
@@ -7,10 +7,11 @@
 from redis import Redis
 
 
-def redis_client(password: str, ssl=False, storage_path="") -> Redis:
+def redis_client(password_enabled: str, password: str, ssl=False, storage_path="") -> Redis:
     """Helper class that creates a Redis connection with variable parameters.
 
     Args:
+        password_enabled: str to check if the connection needs a password (DEPRECATE)
         password: string with the database password
         ssl: boolean, true if the connection requires TLS encryption
         storage_path: string with the path to the container mounted volume
@@ -18,7 +19,12 @@ def redis_client(password: str, ssl=False, storage_path="") -> Redis:
     Returns:
         Redis class with the connection
     """
-    redis = Redis(password=password)
+    redis = Redis()
+
+    # NOTE: This check will become deprecated in the future
+    if password_enabled == "true":
+        redis = Redis(password=password)
+
     if ssl:
         ca_path = f"{storage_path}/ca.crt"
         redis = Redis(password=password, ssl=ssl, ssl_ca_certs=ca_path)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -208,10 +208,8 @@ class TestCharm(TestCase):
         self.assertEqual(rel_data.get("hostname"), "10.2.1.5")
         self.assertEqual(rel_data.get("port"), "6379")
 
-    @mock.patch.object(RedisProvides, "_bind_address")
-    def test_pebble_layer_on_relation_created(self, bind_address):
+    def test_pebble_layer_on_relation_created(self):
         self.harness.set_leader(True)
-        bind_address.return_value = "10.2.1.5"
 
         # Create a relation using 'redis' interface
         rel_id = self.harness.add_relation("redis", "wordpress")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -208,6 +208,34 @@ class TestCharm(TestCase):
         self.assertEqual(rel_data.get("hostname"), "10.2.1.5")
         self.assertEqual(rel_data.get("port"), "6379")
 
+    @mock.patch.object(RedisProvides, "_bind_address")
+    def test_pebble_layer_on_relation_created(self, bind_address):
+        self.harness.set_leader(True)
+        bind_address.return_value = "10.2.1.5"
+
+        # Create a relation using 'redis' interface
+        rel_id = self.harness.add_relation("redis", "wordpress")
+        self.harness.add_relation_unit(rel_id, "wordpress/0")
+        self.harness._emit_relation_created("redis", rel_id, "wordpress/0")
+
+        # Check that the resulting plan does not have a password
+        found_plan = self.harness.get_container_pebble_plan("redis").to_dict()
+        expected_plan = {
+            "services": {
+                "redis": {
+                    "override": "replace",
+                    "summary": "Redis service",
+                    "command": "/usr/local/bin/start-redis.sh redis-server",
+                    "startup": "enabled",
+                    "environment": {
+                        "ALLOW_EMPTY_PASSWORD": "yes",
+                        "REDIS_EXTRA_FLAGS": "",
+                    },
+                }
+            },
+        }
+        self.assertEqual(found_plan, expected_plan)
+
     @mock.patch("charm.RedisK8sCharm._store_certificates")
     def test_attach_resource(self, _store_certificates):
         # Check that there are no resources initially


### PR DESCRIPTION
This PR updates the charm so if the `redis` relation shows up, the charm will disable the password authentication. Some deprecation warnings have been added to the logs.