### PR TITLE
Move relation_created handler to charm.py

### DIFF
--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -44,7 +44,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 3
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -93,18 +93,8 @@ class RedisProvides(Object):
         """A class implementing the redis provides relation."""
         super().__init__(charm, "redis")
         self.framework.observe(charm.on.redis_relation_changed, self._on_relation_changed)
-        self.framework.observe(charm.on.redis_relation_created, self._on_relation_created)
         self._port = port
-        self.charm = charm
 
-    def _on_relation_created(self, _):
-        """Handle the relation created event."""
-        # TODO: Update warning to point to the new interface once it is created
-        logger.warning("DEPRECATION WARNING - `redis` interface is a legacy interface.")
-        if self.charm.unit.is_leader():
-            self.charm._peers.data[self.charm.app]["enable-password"] = "false"
-            self.charm._update_layer()
-    
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
         if not self.model.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ class RedisK8sCharm(CharmBase):
         self.framework.observe(self.on.upgrade_charm, self._upgrade_charm)
         self.framework.observe(self.on.update_status, self._update_status)
         self.framework.observe(self.on.redis_peers_relation_changed, self._peer_relation_changed)
+        self.framework.observe(self.on.redis_relation_created, self._on_redis_relation_created)
 
         self.framework.observe(self.on.check_service_action, self.check_service)
         self.framework.observe(
@@ -125,6 +126,14 @@ class RedisK8sCharm(CharmBase):
         """Handle peer_relation_changed."""
         # NOTE: Updates on legacy `redis` relation only (DEPRECATE)
         if self._peers.data[self.app].get("enable-password", "true") == "false":
+            self._update_layer()
+
+    def _on_redis_relation_created(self, _):
+        """Handle the relation created event."""
+        # TODO: Update warning to point to the new interface once it is created
+        logger.warning("DEPRECATION WARNING - `redis` interface is a legacy interface.")
+        if self.unit.is_leader():
+            self._peers.data[self.app]["enable-password"] = "false"
             self._update_layer()
 
     def _update_layer(self) -> None:


### PR DESCRIPTION
This short PR is just to move the `relation_created` handler for the `redis` relation to `src/charm.py`. This is done to avoid having to update the library on previous versions of the redis charm.

Current `LIBPATCH` for the library is 2, so I'm just reverting it to the way it was.