### PR TITLE
DPE-485 Scale down

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -39,9 +39,6 @@ containers:
         location: /var/lib/redis
   sentinel:
     resource: redis-image
-    mounts:
-      - storage: config
-        location: /etc/redis
 
 resources:
   redis-image:
@@ -62,9 +59,6 @@ storage:
   database:
     type: filesystem
     location: /var/lib/redis
-  config:
-    type: filesystem
-    location: /etc/redis
 
 peers:
   redis-peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -39,6 +39,9 @@ containers:
         location: /var/lib/redis
   sentinel:
     resource: redis-image
+    mounts:
+      - storage: config
+        location: /etc/redis
 
 resources:
   redis-image:
@@ -59,6 +62,9 @@ storage:
   database:
     type: filesystem
     location: /var/lib/redis
+  config:
+    type: filesystem
+    location: /etc/redis
 
 peers:
   redis-peers:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 ops~=1.4.0
 redis~=3.5.3
 jinja2==3.1.1
+tenacity==8.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-ops~=1.4.0
+ops~=1.5.0
 redis~=3.5.3
 jinja2==3.1.1
 tenacity==8.0.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -298,7 +298,7 @@ class RedisK8sCharm(CharmBase):
             logger.warning(
                 "DEPRECATION WARNING - password off, this will be removed on later versions"
             )
-            extra_flags = ["--bind 0.0.0.0"]
+            extra_flags = ["--bind 0.0.0.0", f"--replica-announce-ip {self.unit_pod_hostname}"]
 
         if self.config["enable-tls"]:
             extra_flags += [

--- a/src/charm.py
+++ b/src/charm.py
@@ -544,7 +544,7 @@ class RedisK8sCharm(CharmBase):
 
     def _sentinel_failover(self, departing_unit_name: str) -> None:
         """Try to failover the current master.
-        
+
         This method should only be called from juju leader, to avoid more than one
         sentinel sending failovers concurrently.
         """

--- a/src/charm.py
+++ b/src/charm.py
@@ -534,7 +534,7 @@ class RedisK8sCharm(CharmBase):
 
     def _sentinel_failover(self, departing_unit_name: str) -> None:
         """Try to failover the current master."""
-        if departing_unit_name != self.current_master:
+        if self._k8s_hostname(departing_unit_name) != self.current_master:
             # No failover needed
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,6 +102,13 @@ class RedisK8sCharm(CharmBase):
 
         Additionally, there is a check for departing juju leader on scale-down operations.
         """
+        if not self._get_password():
+            logger.info("Creating password for application")
+            self._peers.data[self.app][PEER_PASSWORD_KEY] = self._generate_password()
+
+        if not self.get_sentinel_password():
+            logger.info("Creating sentinel password")
+            self._peers.data[self.app][SENTINEL_PASSWORD_KEY] = self._generate_password()
         # NOTE: if current_master is not set yet, the application is being deployed for the
         # first time. Otherwise, we check for failover in case previous juju leader was redis
         # master as well.
@@ -123,14 +130,6 @@ class RedisK8sCharm(CharmBase):
 
             logger.info("Resetting sentinel")
             self._reset_sentinel()
-
-        if not self._get_password():
-            logger.info("Creating password for application")
-            self._peers.data[self.app][PEER_PASSWORD_KEY] = self._generate_password()
-
-        if not self.get_sentinel_password():
-            logger.info("Creating sentinel password")
-            self._peers.data[self.app][SENTINEL_PASSWORD_KEY] = self._generate_password()
 
     def _config_changed(self, event: EventBase) -> None:
         """Handle config_changed event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -116,7 +116,7 @@ class RedisK8sCharm(CharmBase):
                 event.defer()
                 return
 
-            logger.warning("Resetting sentinel")
+            logger.info("Resetting sentinel")
             self._reset_sentinel()
 
         if not self._get_password():
@@ -188,7 +188,7 @@ class RedisK8sCharm(CharmBase):
 
         # Quorum is updated beforehand, since removal of more units than current majority
         # could lead to the cluster never reaching quorum.
-        logger.warning("Updating quorum")
+        logger.info("Updating quorum")
         self._update_quorum()
 
         try:
@@ -208,7 +208,7 @@ class RedisK8sCharm(CharmBase):
             event.defer()
             return
 
-        logger.warning("Resetting sentinel")
+        logger.info("Resetting sentinel")
         self._reset_sentinel()
 
         self.unit.status = ActiveStatus()
@@ -469,7 +469,7 @@ class RedisK8sCharm(CharmBase):
             # Fetch the resource path
             return self.model.resources.fetch(resource)
         except (ModelError, NameError) as e:
-            logger.warning(e)
+            logger.info(e)
             return None
 
     def _k8s_hostname(self, name: str) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -550,8 +550,8 @@ class RedisK8sCharm(CharmBase):
                 raise
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_fixed(10),
+        stop=stop_after_attempt(4),
+        wait=wait_fixed(15),
         reraise=True,
         before=before_log(logger, logging.DEBUG),
     )

--- a/src/charm.py
+++ b/src/charm.py
@@ -165,6 +165,11 @@ class RedisK8sCharm(CharmBase):
                 # Update who the current master is
                 self._update_application_master()
 
+        # (DEPRECATE) If legacy relation exists, layer might need to be
+        # reconfigured to remove auth
+        if self._peers.data[self.app].get("enable-password", "true") == "false":
+            self._update_layer()
+
         if not (self.unit.is_leader() and event.unit):
             return
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module with custom exceptions related to the Redis charm."""
+
+
+class RedisOperatorError(Exception):
+    """Base class for exceptions in this module."""
+
+    def __repr__(self):
+        """String representation of the Error class."""
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
+
+    @property
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
+
+    @property
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
+
+class RedisFailoverInProgressError(RedisOperatorError):
+    """Exception raised when creating a user fails."""
+
+
+class RedisFailoverCheckError(RedisOperatorError):
+    """Exception raised when failover status cannot be checked."""

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -24,7 +24,7 @@ class RedisOperatorError(Exception):
 
 
 class RedisFailoverInProgressError(RedisOperatorError):
-    """Exception raised when creating a user fails."""
+    """Exception raised when failover is in progress."""
 
 
 class RedisFailoverCheckError(RedisOperatorError):

--- a/src/literals.py
+++ b/src/literals.py
@@ -14,6 +14,5 @@ SOCKET_TIMEOUT = 1
 REDIS_PORT = 6379
 SENTINEL_PORT = 26379
 
-CONFIG_PATH = "/etc/redis"
-REDIS_CONFIG_PATH = f"{CONFIG_PATH}/redis.conf"
-SENTINEL_CONFIG_PATH = f"{CONFIG_PATH}/sentinel.conf"
+CONFIG_DIR = "/etc/redis-server"
+SENTINEL_CONFIG_PATH = f"{CONFIG_DIR}/sentinel.conf"

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -19,7 +19,13 @@ from ops.model import ActiveStatus, WaitingStatus
 from ops.pebble import Layer
 from redis import ConnectionError, Redis, ResponseError, TimeoutError
 
-from literals import REDIS_PORT, SENTINEL_CONFIG_PATH, SENTINEL_PORT, SOCKET_TIMEOUT
+from literals import (
+    CONFIG_DIR,
+    REDIS_PORT,
+    SENTINEL_CONFIG_PATH,
+    SENTINEL_PORT,
+    SOCKET_TIMEOUT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -122,11 +128,19 @@ class Sentinel(Object):
             logger.warning("Can't connect to {} container".format(container))
             return
 
+        if not container.exists(CONFIG_DIR):
+            container.make_dir(
+                CONFIG_DIR,
+                make_parents=True,
+                permissions=0o770,
+                user="redis",
+                group="redis",
+            )
+
         container.push(
             path,
             rendered,
-            make_dirs=True,
-            permissions=0o600,
+            permissions=0o660,
             user="redis",
             group="redis",
         )

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -128,6 +128,8 @@ class Sentinel(Object):
             logger.warning("Can't connect to {} container".format(container))
             return
 
+        # NOTE: Creating the dir with correct user:group and permissions is needed
+        # until https://github.com/canonical/pebble/issues/124 is fixed.
         if not container.exists(CONFIG_DIR):
             container.make_dir(
                 CONFIG_DIR,

--- a/templates/sentinel.conf.j2
+++ b/templates/sentinel.conf.j2
@@ -1,7 +1,7 @@
 port {{ sentinel_port }}
 sentinel monitor {{ master_name }} {{ redis_master }} {{ redis_port }} {{ quorum }}
-sentinel down-after-milliseconds {{ master_name }} 30000
-sentinel failover-timeout {{ master_name }} 180000
+sentinel down-after-milliseconds {{ master_name }} 5000
+sentinel failover-timeout {{ master_name }} 30000
 sentinel parallel-syncs {{ master_name }} 1
 
 {% if master_password != None %}

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -342,7 +342,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
         client = Redis(address, password=password)
         assert client.get("testKey") == b"myValue"
         client.close()
-    
+
     master_info = sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
     master_info = dict(zip(master_info[::2], master_info[1::2]))
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -324,7 +324,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     # Failover so the last unit becomes master
     sentinel.execute_command(f"SENTINEL FAILOVER {APP_NAME}")
     # Give time so sentinel updates information of failover
-    time.sleep(1)
+    time.sleep(3)
 
     await ops_test.model.block_until(
         lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import time
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -241,7 +242,8 @@ async def test_sentinels_expected(ops_test: OpsTest):
     assert sentinels_connected == NUM_UNITS
 
 
-@pytest.mark.scale_up
+@pytest.mark.run(before="test_scale_down_departing_master")
+@pytest.mark.scaling
 async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     """Trigger a failover and scale up the application, then test replication status."""
     unit_map = await get_unit_map(ops_test)
@@ -293,12 +295,85 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
         assert client.get("testKey") == b"myValue"
         client.close()
 
-    # TODO: scale-down to reset the model once scale-down logic is added
+
+@pytest.mark.run(after="test_scale_up_replication_after_failover")
+@pytest.mark.scaling
+async def test_scale_down_departing_master(ops_test: OpsTest):
+    """Failover to the last unit and scale down."""
+    unit_map = await get_unit_map(ops_test)
+    logger.info("Unit mapping: {}".format(unit_map))
+
+    # NOTE: since this test will run after the previous, we know that the application
+    # has NUM_UNITS + 1 units. Last unit will be application-name/3
+    last_unit = NUM_UNITS
+
+    leader_address = await get_address(ops_test, get_unit_number(unit_map["leader"]))
+    last_address = await get_address(ops_test, last_unit)
+    password = await get_password(ops_test, 0)
+    sentinel_password = await get_sentinel_password(ops_test, 0)
+
+    sentinel = Redis(leader_address, port=26379, password=sentinel_password, decode_responses=True)
+    last_redis = Redis(last_address, password=password, decode_responses=True)
+
+    # INITIAL SETUP #
+    # Sanity check that the added unit on the previous test is not a master
+    assert last_redis.execute_command("ROLE")[0] != "master"
+
+    # Make the added unit a priority during failover
+    last_redis.execute_command("CONFIG SET replica-priority 1")
+    # Failover so the last unit becomes master
+    sentinel.execute_command(f"SENTINEL FAILOVER {APP_NAME}")
+    # Give time so sentinel updates information of failover
+    time.sleep(1)
+
+    await ops_test.model.block_until(
+        lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
+    )
+    assert last_redis.execute_command("ROLE")[0] == "master"
+
+    last_redis.close()
+
+    # SCALE DOWN #
+    await scale(ops_test, scale=NUM_UNITS)
+
+    # Check that the initial key is still replicated across units
+    for i in range(NUM_UNITS):
+        address = await get_address(ops_test, i)
+        client = Redis(address, password=password)
+        assert client.get("testKey") == b"myValue"
+        client.close()
+    
+    master_info = sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
+    master_info = dict(zip(master_info[::2], master_info[1::2]))
+
+    # General checks that the system is reconfigured after departed leader
+    assert master_info["num-slaves"] == "2"
+    assert master_info["quorum"] == "2"
+    assert master_info["num-other-sentinels"] == "2"
+
+    sentinel.close()
 
 
 ##################
 # Helper methods #
 ##################
+
+
+async def scale(ops_test: OpsTest, scale: int) -> None:
+    """Scale the application to the provided number and wait for idle."""
+    await ops_test.model.applications[APP_NAME].scale(scale=scale)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[APP_NAME].units) == scale
+    )
+
+    # Wait for model to settle
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        idle_period=30,
+        raise_on_blocked=True,
+        timeout=1000,
+    )
 
 
 async def get_password(ops_test: OpsTest, num_unit=0) -> str:


### PR DESCRIPTION
# Issue

This PR addresses Jira ticket [DPE-485](https://warthogs.atlassian.net/browse/DPE-485).
Logic for scaling-down has been added.

## Solution

During scale-down, new quorum will be propagated and a reset command will be sent to all sentinels, so they remove information form departing `redis-server` and `sentinel`.
- In the event of one of the departing units being the current replication master, a manual failover will be triggered, so a new master is elected.

## Context

Some changes have been made to the initial command. The initial replication master needs replica flags as well. When a failover occurs, the old master will need those flags so it can become a secondary successfully.

## Release Notes

- `charm.py`
   - `_peer_relation_departing()` now handles scale-down logic
   - `_leader_elected()` added logic in the case juju leader departs and it was redis master
   - reworked sentinel command helpers
   - redis pebble layer bugs after failover fixed 
   - added `_sentinel_failover()` to trigger a manual failover
   - `_is_failover_finished()`
- Added custom exceptions
- Fixed directory creation for sentinel
- Updated sentinel template so failovers timeout are faster

## Testing

Unit tests using the pebble layer have been fixed to take changes into account.

### Unit

- Test application data updated after a failover happens.
- Test manual failover when departing unit is replication master.

### Integration

- Added scale down on departing redis master test.

