### PR TITLE
DPE-403 Redis relation integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox -e integration-redis -- --model testing
+        run: tox -e integration-relation -- --model testing
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  integration-test-microk8s:
-    name: Integration tests (microk8s)
+  integration-test-general:
+    name: Integration tests (general)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +41,27 @@ jobs:
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
         run: tox -e integration -- --model testing
+      - name: Dump logs
+        uses: canonical/charm-logdump-action@main
+        if: failure()
+        with:
+          app: redis-k8s
+          model: testing
+  integration-test-relation:
+    name: Integration tests (relation)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
+          bootstrap-options: "--agent-version 2.9.29"
+      - name: Run integration tests
+        # set a predictable model name so it can be consumed by charm-logdump-action
+        run: tox -e integration-redis -- --model testing
       - name: Dump logs
         uses: canonical/charm-logdump-action@main
         if: failure()

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -99,11 +99,6 @@ class RedisProvides(Object):
 
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
-        """
-        if not self.model.unit.is_leader():
-            logger.debug("Relation changes ignored by non-leader")
-            return
-        """
         event.relation.data[self.model.unit]['hostname'] = self._get_master_ip()
         event.relation.data[self.model.unit]['port'] = str(self._port)
         # The reactive Redis charm also exposes 'password'. When tackling

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -99,10 +99,11 @@ class RedisProvides(Object):
 
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
+        """
         if not self.model.unit.is_leader():
             logger.debug("Relation changes ignored by non-leader")
             return
-
+        """
         event.relation.data[self.model.unit]['hostname'] = self._get_master_ip()
         event.relation.data[self.model.unit]['port'] = str(self._port)
         # The reactive Redis charm also exposes 'password'. When tackling

--- a/src/charm.py
+++ b/src/charm.py
@@ -144,6 +144,7 @@ class RedisK8sCharm(CharmBase):
             return
 
         self._update_layer()
+        self.sentinel._update_sentinel_layer()
 
         # update_layer will set a Waiting status if Pebble is not ready
         if not isinstance(self.unit.status, ActiveStatus):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -69,11 +69,11 @@ async def change_config(ops_test: OpsTest, values: dict) -> None:
     await ops_test.model.applications[APP_NAME].set_config(values)
 
 
-async def get_address(ops_test: OpsTest, unit_num=0) -> str:
+async def get_address(ops_test: OpsTest, app_name=APP_NAME, unit_num=0) -> str:
     """Get the address for a unit."""
     logger.info(f"Getting the address for unit {unit_num}")
     status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{unit_num}"]["address"]
+    address = status["applications"][app_name]["units"][f"{app_name}/{unit_num}"]["address"]
     return address
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,8 +4,10 @@
 
 """Helpers for integration tests."""
 import logging
+from urllib.request import urlopen
 
 from pytest_operator.plugin import OpsTest
+from tenacity import before_log, retry, stop_after_attempt, wait_fixed
 
 from tests.helpers import APP_NAME
 
@@ -103,3 +105,17 @@ def get_unit_number(unit_name: str) -> str:
     Unit names look like `application-name/0`
     """
     return unit_name.split("/")[1]
+
+
+@retry(
+    stop=stop_after_attempt(15),
+    wait=wait_fixed(20),
+    reraise=True,
+    before=before_log(logger, logging.DEBUG),
+)
+def query_url(url: str):
+    """Connect to a url and return the result."""
+    logger.info("Trying to connect to: {}".format(url))
+    response = urlopen(url)
+
+    return response

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers for integration tests."""
+import logging
+
+from pytest_operator.plugin import OpsTest
+
+from tests.helpers import APP_NAME
+
+logger = logging.getLogger(__name__)
+
+
+async def scale(ops_test: OpsTest, scale: int) -> None:
+    """Scale the application to the provided number and wait for idle."""
+    await ops_test.model.applications[APP_NAME].scale(scale=scale)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[APP_NAME].units) == scale
+    )
+
+    # Wait for model to settle
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        idle_period=30,
+        raise_on_blocked=True,
+        timeout=1000,
+    )
+
+
+async def get_password(ops_test: OpsTest, num_unit=0) -> str:
+    """Use the charm action to retrieve the password.
+
+    Return:
+        String with the password stored on the peer relation databag.
+    """
+    logger.info(f"Calling action to get password for unit {num_unit}")
+    action = await ops_test.model.units.get(f"{APP_NAME}/{num_unit}").run_action(
+        "get-initial-admin-password"
+    )
+    password = await action.wait()
+    return password.results["redis-password"]
+
+
+async def get_sentinel_password(ops_test: OpsTest, num_unit=0) -> str:
+    """Use the charm action to retrieve the sentinel password.
+
+    Return:
+        String with the password stored on the peer relation databag.
+    """
+    logger.info(f"Calling action to get sentinel password for unit {num_unit}")
+    action = await ops_test.model.units.get(f"{APP_NAME}/{num_unit}").run_action(
+        "get-sentinel-password"
+    )
+    password = await action.wait()
+    return password.results["sentinel-password"]
+
+
+async def attach_resource(ops_test: OpsTest, rsc_name: str, rsc_path: str) -> None:
+    """Use the `juju attach-resource` command to add resources."""
+    logger.info(f"Attaching resource: attach-resource {APP_NAME} {rsc_name}={rsc_path}")
+    await ops_test.juju("attach-resource", APP_NAME, f"{rsc_name}={rsc_path}")
+
+
+async def change_config(ops_test: OpsTest, values: dict) -> None:
+    """Use the `juju config` command to modify a config option."""
+    logger.info(f"Changing config options: {values}")
+    await ops_test.model.applications[APP_NAME].set_config(values)
+
+
+async def get_address(ops_test: OpsTest, unit_num=0) -> str:
+    """Get the address for a unit."""
+    logger.info(f"Getting the address for unit {unit_num}")
+    status = await ops_test.model.get_status()  # noqa: F821
+    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{unit_num}"]["address"]
+    return address
+
+
+async def get_unit_map(ops_test: OpsTest) -> dict:
+    """Get a map of unit names.
+
+    Returns:
+        unit_map : {
+            "leader": "redis-k8s/0",
+            "non_leader": ["redis-k8s/1", "redis-k8s/1"]
+        }
+    """
+    unit_map = {"leader": None, "non_leader": []}
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if await unit.is_leader_from_status():
+            # Get the number from the unit
+            unit_map["leader"] = unit.name
+        else:
+            unit_map["non_leader"].append(unit.name)
+
+    return unit_map
+
+
+def get_unit_number(unit_name: str) -> str:
+    """Get the unit number from it's complete name.
+
+    Unit names look like `application-name/0`
+    """
+    return unit_name.split("/")[1]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -217,7 +217,7 @@ async def test_replication(ops_test: OpsTest):
 
     leader_num = get_unit_number(unit_map["leader"])
     leader_address = await get_address(ops_test, unit_num=leader_num)
-    password = await get_password(ops_test, unit_num=leader_num)
+    password = await get_password(ops_test, leader_num)
 
     leader_client = Redis(leader_address, password=password)
     leader_client.set("testKey", "myValue")
@@ -319,8 +319,8 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
 
     leader_address = await get_address(ops_test, unit_num=get_unit_number(unit_map["leader"]))
     last_address = await get_address(ops_test, unit_num=last_unit)
-    password = await get_password(ops_test, 0)
-    sentinel_password = await get_sentinel_password(ops_test, 0)
+    password = await get_password(ops_test)
+    sentinel_password = await get_sentinel_password(ops_test)
 
     sentinel = Redis(leader_address, port=26379, password=sentinel_password, decode_responses=True)
     last_redis = Redis(last_address, password=password, decode_responses=True)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -300,7 +300,7 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     unit_map = await get_unit_map(ops_test)
     # Check that the initial key is still replicated across units
     for i in range(NUM_UNITS + 1):
-        address = await get_address(ops_test, i)
+        address = await get_address(ops_test, unit_num=i)
         client = Redis(address, password=password)
         assert client.get("testKey") == b"myValue"
         client.close()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -216,8 +216,8 @@ async def test_replication(ops_test: OpsTest):
     logger.info("Unit mapping: {}".format(unit_map))
 
     leader_num = get_unit_number(unit_map["leader"])
-    leader_address = await get_address(ops_test, leader_num)
-    password = await get_password(ops_test, leader_num)
+    leader_address = await get_address(ops_test, unit_num=leader_num)
+    password = await get_password(ops_test, unit_num=leader_num)
 
     leader_client = Redis(leader_address, password=password)
     leader_client.set("testKey", "myValue")
@@ -225,7 +225,7 @@ async def test_replication(ops_test: OpsTest):
     # Check that the initial key has been replicated across units
     for unit_name in unit_map["non_leader"]:
         unit_num = get_unit_number(unit_name)
-        address = await get_address(ops_test, unit_num)
+        address = await get_address(ops_test, unit_num=unit_num)
 
         client = Redis(address, password=password)
         assert client.get("testKey") == b"myValue"
@@ -241,7 +241,7 @@ async def test_sentinels_expected(ops_test: OpsTest):
     """Test sentinel connection and expected number of sentinels."""
     unit_map = await get_unit_map(ops_test)
     leader_num = get_unit_number(unit_map["leader"])
-    address = await get_address(ops_test, leader_num)
+    address = await get_address(ops_test, unit_num=leader_num)
     # Use action to get admin password
     password = await get_sentinel_password(ops_test)
     logger.info("retrieved sentinel password for %s: %s", APP_NAME, password)
@@ -260,7 +260,7 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     logger.info("Unit mapping: {}".format(unit_map))
 
     leader_num = get_unit_number(unit_map["leader"])
-    leader_address = await get_address(ops_test, leader_num)
+    leader_address = await get_address(ops_test, unit_num=leader_num)
     password = await get_password(ops_test, leader_num)
 
     # Set some key on the master replica.
@@ -317,8 +317,8 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     # has NUM_UNITS + 1 units. Last unit will be application-name/3
     last_unit = NUM_UNITS
 
-    leader_address = await get_address(ops_test, get_unit_number(unit_map["leader"]))
-    last_address = await get_address(ops_test, last_unit)
+    leader_address = await get_address(ops_test, unit_num=get_unit_number(unit_map["leader"]))
+    last_address = await get_address(ops_test, unit_num=last_unit)
     password = await get_password(ops_test, 0)
     sentinel_password = await get_sentinel_password(ops_test, 0)
 
@@ -348,7 +348,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
 
     # Check that the initial key is still replicated across units
     for i in range(NUM_UNITS):
-        address = await get_address(ops_test, i)
+        address = await get_address(ops_test, unit_num=i)
         client = Redis(address, password=password)
         assert client.get("testKey") == b"myValue"
         client.close()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -103,11 +103,15 @@ async def test_same_password_after_scaling(ops_test: OpsTest):
 
     logger.info("scaling charm %s to 0 units", APP_NAME)
     await ops_test.model.applications[APP_NAME].scale(scale=0)
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 0)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[APP_NAME].units) == 0, timeout=600
+    )
 
     logger.info("scaling charm %s to 1 units", APP_NAME)
     await ops_test.model.applications[APP_NAME].scale(scale=1)
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) > 0)
+    await ops_test.model.block_until(
+        lambda: len(ops_test.model.applications[APP_NAME].units) > 0, timeout=600
+    )
 
     # Wait for model to settle
     await ops_test.model.wait_for_idle(
@@ -131,7 +135,8 @@ async def test_same_password_after_scaling(ops_test: OpsTest):
     logger.info("scaling charm back to %s units", NUM_UNITS)
     await ops_test.model.applications[APP_NAME].scale(scale=NUM_UNITS)
     await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS
+        lambda: len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS,
+        timeout=300,
     )
     # Wait for model to settle
     await ops_test.model.wait_for_idle(
@@ -277,7 +282,8 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
 
     await ops_test.model.applications[APP_NAME].scale(scale=NUM_UNITS + 1)
     await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS + 1
+        lambda: len(ops_test.model.applications[APP_NAME].units) == NUM_UNITS + 1,
+        timeout=300,
     )
 
     # Wait for model to settle
@@ -337,7 +343,8 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     time.sleep(3)
 
     await ops_test.model.block_until(
-        lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
+        lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}"),
+        timeout=60,
     )
     assert last_redis.execute_command("ROLE")[0] == "master"
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -12,6 +12,16 @@ from redis import Redis
 from redis.exceptions import AuthenticationError
 
 from tests.helpers import APP_NAME, METADATA, NUM_UNITS, TLS_RESOURCES
+from tests.integration.helpers import (
+    attach_resource,
+    change_config,
+    get_address,
+    get_password,
+    get_sentinel_password,
+    get_unit_map,
+    get_unit_number,
+    scale,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -352,101 +362,3 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     assert master_info["num-other-sentinels"] == "2"
 
     sentinel.close()
-
-
-##################
-# Helper methods #
-##################
-
-
-async def scale(ops_test: OpsTest, scale: int) -> None:
-    """Scale the application to the provided number and wait for idle."""
-    await ops_test.model.applications[APP_NAME].scale(scale=scale)
-    await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APP_NAME].units) == scale
-    )
-
-    # Wait for model to settle
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        idle_period=30,
-        raise_on_blocked=True,
-        timeout=1000,
-    )
-
-
-async def get_password(ops_test: OpsTest, num_unit=0) -> str:
-    """Use the charm action to retrieve the password.
-
-    Return:
-        String with the password stored on the peer relation databag.
-    """
-    logger.info(f"Calling action to get password for unit {num_unit}")
-    action = await ops_test.model.units.get(f"{APP_NAME}/{num_unit}").run_action(
-        "get-initial-admin-password"
-    )
-    password = await action.wait()
-    return password.results["redis-password"]
-
-
-async def get_sentinel_password(ops_test: OpsTest, num_unit=0) -> str:
-    """Use the charm action to retrieve the sentinel password.
-
-    Return:
-        String with the password stored on the peer relation databag.
-    """
-    logger.info(f"Calling action to get sentinel password for unit {num_unit}")
-    action = await ops_test.model.units.get(f"{APP_NAME}/{num_unit}").run_action(
-        "get-sentinel-password"
-    )
-    password = await action.wait()
-    return password.results["sentinel-password"]
-
-
-async def attach_resource(ops_test: OpsTest, rsc_name: str, rsc_path: str) -> None:
-    """Use the `juju attach-resource` command to add resources."""
-    logger.info(f"Attaching resource: attach-resource {APP_NAME} {rsc_name}={rsc_path}")
-    await ops_test.juju("attach-resource", APP_NAME, f"{rsc_name}={rsc_path}")
-
-
-async def change_config(ops_test: OpsTest, values: dict) -> None:
-    """Use the `juju config` command to modify a config option."""
-    logger.info(f"Changing config options: {values}")
-    await ops_test.model.applications[APP_NAME].set_config(values)
-
-
-async def get_address(ops_test: OpsTest, unit_num=0) -> str:
-    """Get the address for a unit."""
-    logger.info(f"Getting the address for unit {unit_num}")
-    status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/{unit_num}"]["address"]
-    return address
-
-
-async def get_unit_map(ops_test: OpsTest) -> dict:
-    """Get a map of unit names.
-
-    Returns:
-        unit_map : {
-            "leader": "redis-k8s/0",
-            "non_leader": ["redis-k8s/1", "redis-k8s/1"]
-        }
-    """
-    unit_map = {"leader": None, "non_leader": []}
-    for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            # Get the number from the unit
-            unit_map["leader"] = unit.name
-        else:
-            unit_map["non_leader"].append(unit.name)
-
-    return unit_map
-
-
-def get_unit_number(unit_name: str) -> str:
-    """Get the unit number from it's complete name.
-
-    Unit names look like `application-name/0`
-    """
-    return unit_name.split("/")[1]

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -7,10 +7,9 @@ import logging
 
 import pytest as pytest
 from pytest_operator.plugin import OpsTest
-from redis import Redis
 
 from tests.helpers import APP_NAME, METADATA, NUM_UNITS
-from tests.integration.helpers import get_address, get_unit_map
+from tests.integration.helpers import get_address
 
 FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
 SECOND_DISCOURSE_APP_NAME = "discourse-charmers-discourse-k8s"
@@ -57,6 +56,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(
             apps=[FIRST_DISCOURSE_APP_NAME], status="blocked", timeout=1000
         )
+
 
 @pytest.mark.order(2)
 @pytest.mark.redis_tests

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -77,9 +77,9 @@ async def test_discourse_relation(ops_test: OpsTest):
     # Test the first Discourse charm.
     # Add both relations to Discourse (PostgreSQL and Redis)
     # and wait for it to be ready.
-    await ops_test.model.add_relation(f"{POSTGRESQL_APP_NAME}:db-admin", FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(f"{POSTGRESQL_APP_NAME}:db-admin", FIRST_DISCOURSE_APP_NAME)
     # Wait until discourse handles all relation events related to postgresql
-    await ops_test.model.add_relation(APP_NAME, FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(APP_NAME, FIRST_DISCOURSE_APP_NAME)
 
     # This won't work: model.applications[app_name].units[0].workload_status returns wrong status
     """

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -76,9 +76,14 @@ async def test_discourse(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, FIRST_DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
         status="active",
-        timeout=2000,  # Discourse takes a longer time to become active (a lot of setup).
+        timeout=3000,  # Discourse takes a longer time to become active (a lot of setup).
     )
 
+
+@pytest.mark.order(3)
+@pytest.mark.redis_tests
+async def test_discourse_request(ops_test: OpsTest):
+    """Try to connect to discourse after the bundle is deployed."""
     discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = urlopen(url)
@@ -86,6 +91,7 @@ async def test_discourse(ops_test: OpsTest):
     assert response.status == 200
 
 
+@pytest.mark.order(4)
 @pytest.mark.redis_tests
 async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
     """Test the second Discourse charm."""

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest as pytest
+from pytest_operator.plugin import OpsTest
+from redis import Redis
+
+from tests.helpers import APP_NAME, METADATA, NUM_UNITS
+from tests.integration.helpers import get_address, get_unit_map
+
+FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
+SECOND_DISCOURSE_APP_NAME = "discourse-charmers-discourse-k8s"
+POSTGRESQL_APP_NAME = "postgresql-k8s"
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.order(1)
+@pytest.mark.redis_tests
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest):
+    """Build the charm-under-test and deploy it.
+
+    Assert on the unit status before any relations/configurations take place.
+    """
+    async with ops_test.fast_forward():
+        # Build and deploy charm from local source folder (and also postgresql from Charmhub)
+        # Both are needed by Discourse charms.
+        charm = await ops_test.build_charm(".")
+        resources = {
+            "redis-image": METADATA["resources"]["redis-image"]["upstream"],
+            "cert-file": METADATA["resources"]["cert-file"]["filename"],
+            "key-file": METADATA["resources"]["key-file"]["filename"],
+            "ca-cert-file": METADATA["resources"]["ca-cert-file"]["filename"],
+        }
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                resources=resources,
+                application_name=APP_NAME,
+                trust=True,
+                num_units=NUM_UNITS,
+            ),
+            ops_test.model.deploy(
+                FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME
+            ),
+            ops_test.model.deploy(POSTGRESQL_APP_NAME, application_name=POSTGRESQL_APP_NAME),
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME, POSTGRESQL_APP_NAME], status="active", timeout=1000
+        )
+        # Discourse becomes blocked waiting for relations.
+        await ops_test.model.wait_for_idle(
+            apps=[FIRST_DISCOURSE_APP_NAME], status="blocked", timeout=1000
+        )
+
+@pytest.mark.order(2)
+@pytest.mark.redis_tests
+async def test_discourse(ops_test: OpsTest):
+    # Test the first Discourse charm.
+    # Add both relations to Discourse (PostgreSQL and Redis)
+    # and wait for it to be ready.
+    await ops_test.model.add_relation(
+        APP_NAME,
+        FIRST_DISCOURSE_APP_NAME,
+    )
+    await ops_test.model.add_relation(
+        f"{POSTGRESQL_APP_NAME}:db-admin",
+        FIRST_DISCOURSE_APP_NAME,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, FIRST_DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
+        status="active",
+        timeout=2000,  # Discourse takes a longer time to become active (a lot of setup).
+    )
+
+
+@pytest.mark.order(3)
+@pytest.mark.redis_tests
+async def test_keys_replicated(ops_test: OpsTest):
+    """"""
+
+
+@pytest.mark.redis_tests
+async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
+    # Test the second Discourse charm.
+
+    # Get the Redis instance IP address.
+    redis_host = await get_address(ops_test, f"{APP_NAME}/0")
+
+    # Deploy Discourse and wait for it to be blocked waiting for database relation.
+    await ops_test.model.deploy(
+        SECOND_DISCOURSE_APP_NAME,
+        application_name=SECOND_DISCOURSE_APP_NAME,
+        config={
+            "redis_host": redis_host,
+            "developer_emails": "user@foo.internal",
+            "external_hostname": "foo.internal",
+            "smtp_address": "127.0.0.1",
+            "smtp_domain": "foo.internal",
+        },
+    )
+    # Discourse becomes blocked waiting for PostgreSQL relation.
+    await ops_test.model.wait_for_idle(
+        apps=[SECOND_DISCOURSE_APP_NAME], status="blocked", timeout=1000
+    )
+
+    # Relate PostgreSQL and Discourse, waiting for Discourse to be ready.
+    await ops_test.model.add_relation(
+        f"{POSTGRESQL_APP_NAME}:db-admin",
+        SECOND_DISCOURSE_APP_NAME,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[POSTGRESQL_APP_NAME, SECOND_DISCOURSE_APP_NAME, APP_NAME],
+        status="active",
+        timeout=2000,  # Discourse takes a longer time to become active (a lot of setup).
+    )

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+from urllib.request import urlopen
 
 import pytest as pytest
 from pytest_operator.plugin import OpsTest
@@ -78,11 +79,11 @@ async def test_discourse(ops_test: OpsTest):
         timeout=2000,  # Discourse takes a longer time to become active (a lot of setup).
     )
 
+    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
+    url = f"http://{discourse_ip}:3000/site.json"
+    response = urlopen(url)
 
-@pytest.mark.order(3)
-@pytest.mark.redis_tests
-async def test_keys_replicated(ops_test: OpsTest):
-    """"""
+    assert response.status == 200
 
 
 @pytest.mark.redis_tests
@@ -91,7 +92,7 @@ async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
     unit_map = await get_unit_map(ops_test)
 
     # Get the Redis instance IP address.
-    redis_host = await get_address(ops_test, get_unit_number(unit_map["leader"]))
+    redis_host = await get_address(ops_test, unit_num=get_unit_number(unit_map["leader"]))
 
     # Deploy Discourse and wait for it to be blocked waiting for database relation.
     await ops_test.model.deploy(

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -9,7 +9,7 @@ import pytest as pytest
 from pytest_operator.plugin import OpsTest
 
 from tests.helpers import APP_NAME, METADATA, NUM_UNITS
-from tests.integration.helpers import get_address
+from tests.integration.helpers import get_address, get_unit_map, get_unit_number
 
 FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
 SECOND_DISCOURSE_APP_NAME = "discourse-charmers-discourse-k8s"
@@ -87,10 +87,11 @@ async def test_keys_replicated(ops_test: OpsTest):
 
 @pytest.mark.redis_tests
 async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
-    # Test the second Discourse charm.
+    """Test the second Discourse charm."""
+    unit_map = await get_unit_map(ops_test)
 
     # Get the Redis instance IP address.
-    redis_host = await get_address(ops_test, f"{APP_NAME}/0")
+    redis_host = await get_address(ops_test, get_unit_number(unit_map["leader"]))
 
     # Deploy Discourse and wait for it to be blocked waiting for database relation.
     await ops_test.model.deploy(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -154,7 +154,7 @@ class TestCharm(TestCase):
         mock_container.restart.assert_not_called()
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for Pebble in workload container"),
+            WaitingStatus("Waiting for Pebble in sentinel container"),
         )
         self.assertEqual(self.harness.charm.app.status, UnknownStatus())
         self.assertEqual(self.harness.get_workload_version(), None)
@@ -196,11 +196,11 @@ class TestCharm(TestCase):
             admin_password,
         )
 
-    @mock.patch.object(RedisProvides, "_bind_address")
-    def test_on_relation_changed_status_when_unit_is_leader(self, bind_address):
+    @mock.patch.object(RedisProvides, "_get_master_ip")
+    def test_on_relation_changed_status_when_unit_is_leader(self, get_master_ip):
         # Given
         self.harness.set_leader(True)
-        bind_address.return_value = "10.2.1.5"
+        get_master_ip.return_value = "10.2.1.5"
 
         rel_id = self.harness.add_relation("redis", "wordpress")
         self.harness.add_relation_unit(rel_id, "wordpress/0")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -152,10 +152,8 @@ class TestCharm(TestCase):
         self.harness.update_config()
         mock_container.add_layer.assert_not_called()
         mock_container.restart.assert_not_called()
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            WaitingStatus("Waiting for Pebble in sentinel container"),
-        )
+        self.assertTrue(isinstance(self.harness.charm.unit.status, WaitingStatus))
+
         self.assertEqual(self.harness.charm.app.status, UnknownStatus())
         self.assertEqual(self.harness.get_workload_version(), None)
         # TODO - test for the event being deferred

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
 commands =
     # Generate TLS certificates to use during tests
     sh -c "./tests/gen-test-certs.sh"
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0 {[vars]tst_path}integration/test_charm.py
     sh -c "rm -f tests/tls/*"
 whitelist_externals =
     sh

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ deps =
     pytest
     juju
     pytest-operator
+    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     # Generate TLS certificates to use during tests
@@ -79,3 +80,14 @@ commands =
     sh -c "rm -f tests/tls/*"
 whitelist_externals =
     sh
+
+[testenv:integration-redis]
+description = Run integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    pytest-order
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "redis_tests" --durations=0

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands =
 whitelist_externals =
     sh
 
-[testenv:integration-redis]
+[testenv:integration-relation]
 description = Run integration tests
 deps =
     pytest


### PR DESCRIPTION
# Issue

This PR addresses Jira ticket [DPE-403](https://warthogs.atlassian.net/browse/DPE-403).
Adding integration tests for legacy relations.

## Solution

The discourse bundle has been used to test `redis` relation interface. The deployment uses both discourse and postgresql charms.

## Release Notes

- `lib/charms/redis-k8s/v0/redis.py`: `provider` side of the lib has been updated to reflect changes and keep an updated replication primary.
- Integration tests have been refactored into different files
- Helper methods now live on their own file as well

## Testing

Unit tests using the pebble layer have been fixed to take changes into account.

### Unit

Changed mock object for some tests.

### Integration

- Deployment of `discourse-k8s` and `postgresql-k8s`. Added relations between discourse-redis & discourse-postgresql

