### PR TITLE
Update stored state on redis relation joined

### DIFF
--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -63,6 +63,7 @@ class RedisRequires(Object):
     def __init__(self, charm, _stored):
         """A class implementing the redis requires relation."""
         super().__init__(charm, "redis")
+        self.framework.observe(charm.on.redis_relation_joined, self._on_relation_changed)
         self.framework.observe(charm.on.redis_relation_changed, self._on_relation_changed)
         self.framework.observe(charm.on.redis_relation_broken, self._on_relation_broken)
         self._stored = _stored

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -236,7 +236,7 @@ async def test_replication(ops_test: OpsTest):
         assert client.get("testKey") == b"myValue"
         client.close()
 
-    # Reset database satus
+    # Reset database status
     leader_client.delete("testKey")
     leader_client.close()
 


### PR DESCRIPTION
In the event of scaling up a consumer application, the redis library does not populate the stored state when the relation for the new unit is created. This PR addresses this issue.

This change has been tested manually deploying redis along with the indico charm.