### PR TITLE
Update OCI image to redis 7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
-          resource-overrides: "redis-image:2"
+          resource-overrides: "redis-image:3"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,7 +44,7 @@ resources:
   redis-image:
     type: oci-image
     description: ubuntu lts docker image for redis
-    upstream: redis:6.2
+    upstream: dataplatformoci/redis:7.0-22.04_edge
   cert-file:
     type: file
     filename: redis.crt

--- a/src/charm.py
+++ b/src/charm.py
@@ -308,7 +308,11 @@ class RedisK8sCharm(CharmBase):
             logger.warning(
                 "DEPRECATION WARNING - password off, this will be removed on later versions"
             )
-            extra_flags = ["--bind 0.0.0.0", f"--replica-announce-ip {self.unit_pod_hostname}"]
+            extra_flags = [
+                "--bind 0.0.0.0",
+                f"--replica-announce-ip {self.unit_pod_hostname}",
+                "--protected-mode no",
+            ]
 
         if self.config["enable-tls"]:
             extra_flags += [

--- a/src/charm.py
+++ b/src/charm.py
@@ -202,20 +202,20 @@ class RedisK8sCharm(CharmBase):
         self._update_quorum()
 
         try:
-            self._sentinel_failover(event.departing_unit.name)
-        except RedisError as e:
-            msg = f"Error on failover: {e}"
-            logger.error(msg)
-            self.unit.status == BlockedStatus(msg)
-            return
-
-        try:
             self._is_failover_finished()
         except (RedisFailoverCheckError, RedisFailoverInProgressError):
             msg = "Failover didn't finish, deferring"
             logger.info(msg)
             self.unit.status == WaitingStatus(msg)
             event.defer()
+            return
+
+        try:
+            self._sentinel_failover(event.departing_unit.name)
+        except RedisError as e:
+            msg = f"Error on failover: {e}"
+            logger.error(msg)
+            self.unit.status == BlockedStatus(msg)
             return
 
         logger.info("Resetting sentinel")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -280,7 +280,7 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     sentinel = Redis(leader_address, password=sentinel_password, port=26379, decode_responses=True)
     sentinel.execute_command(f"SENTINEL failover {APP_NAME}")
     # Give time so sentinel updates information of failover
-    time.sleep(10)
+    time.sleep(60)
 
     await ops_test.model.block_until(
         lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}"),
@@ -348,7 +348,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     # Failover so the last unit becomes master
     sentinel.execute_command(f"SENTINEL FAILOVER {APP_NAME}")
     # Give time so sentinel updates information of failover
-    time.sleep(10)
+    time.sleep(60)
 
     await ops_test.model.block_until(
         lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}"),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -279,6 +279,13 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     # Trigger a master failover
     sentinel = Redis(leader_address, password=sentinel_password, port=26379, decode_responses=True)
     sentinel.execute_command(f"SENTINEL failover {APP_NAME}")
+    # Give time so sentinel updates information of failover
+    time.sleep(10)
+
+    await ops_test.model.block_until(
+        lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}"),
+        timeout=60,
+    )
 
     await ops_test.model.applications[APP_NAME].scale(scale=NUM_UNITS + 1)
     await ops_test.model.block_until(
@@ -341,7 +348,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
     # Failover so the last unit becomes master
     sentinel.execute_command(f"SENTINEL FAILOVER {APP_NAME}")
     # Give time so sentinel updates information of failover
-    time.sleep(3)
+    time.sleep(10)
 
     await ops_test.model.block_until(
         lambda: "failover-status" not in sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}"),
@@ -352,7 +359,6 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
 
     # SCALE DOWN #
     await scale(ops_test, scale=NUM_UNITS)
-    time.sleep(140)  # Sentinel takes time to propagate the reset command to all instances
 
     # Check that the initial key is still replicated across units
     for i in range(NUM_UNITS):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -222,6 +222,7 @@ class TestCharm(TestCase):
         extra_flags = [
             "--bind 0.0.0.0",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
+            "--protected-mode no",
         ]
         expected_plan = {
             "services": {


### PR DESCRIPTION
The charm will now use [Redis 7.0](https://hub.docker.com/r/dataplatformoci/redis/tags). Solves https://github.com/canonical/redis-k8s-operator/issues/45

The change adding `--protected-mode no` is done so Redis doesn't warn of a unsecure mode being used (the password is not used for legacy relation)