### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -23,8 +24,12 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   integration-test-general:
     name: Integration tests (general)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +45,9 @@ jobs:
 
   integration-test-relation:
     name: Integration tests (relation)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,9 @@ jobs:
 
   integration-test-general:
     name: Integration tests (general)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,8 +59,12 @@ jobs:
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration
+
   integration-test-relation:
     name: Integration tests (relation)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.

## Issue
It will resolve https://warthogs.atlassian.net/browse/DPE-781

## Solution
Cost optimization for tests execution.

## Context
GitHub actions tests only.

## Release Notes
Run integration tests for passed lint/unit tests only

## Testing
Tested automatically by GitHub actions only.