### PR TITLE
fix: Pin juju version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,8 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju
+    # This is needed because of https://github.com/juju/python-libjuju/pull/698
+    juju==2.9.11
     pytest-operator
     lightkube==0.10.0
     -r{toxinidir}/requirements.txt
@@ -93,7 +94,8 @@ commands =
 description = Run scaling integration tests
 deps =
     pytest
-    juju
+    # This is needed because of https://github.com/juju/python-libjuju/pull/698
+    juju==2.9.11
     pytest-operator
     pytest-order
     -r{toxinidir}/requirements.txt
@@ -104,7 +106,8 @@ commands =
 description = Run password integration tests
 deps =
     pytest
-    juju
+    # This is needed because of https://github.com/juju/python-libjuju/pull/698
+    juju==2.9.11
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
@@ -114,7 +117,8 @@ commands =
 description = Run integration tests for redis relation
 deps =
     pytest
-    juju
+    # This is needed because of https://github.com/juju/python-libjuju/pull/698
+    juju==2.9.11
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Pin juju version so CI doesn't fail. See: https://github.com/juju/python-libjuju/pull/698