### PR TITLE
Update relation data when the charm pod restarted in a single unit deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,24 @@ jobs:
       - name: Run integration tests
         run: tox -e integration-relation
 
+  integration-test-relation-single-unit:
+    name: Integration tests (relation, num_units=1)
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
+          bootstrap-options: "--agent-version 2.9.29"
+      - name: Run integration tests
+        run: tox -e integration-relation -- --num-units 1
+
   integration-test-password:
     name: Integration tests (password)
     needs:

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,7 +105,9 @@ class RedisK8sCharm(CharmBase):
             # case of the single unit deployment.
             self._peers.data[self.app][LEADER_HOST_KEY] = self.unit_pod_hostname
             for relation in self.model.relations[REDIS_REL_NAME]:
-                relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.unit_pod_hostname)
+                relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
+                    self.unit_pod_hostname
+                )
             return
 
         # Pick a different unit to connect to sentinel
@@ -217,7 +219,9 @@ class RedisK8sCharm(CharmBase):
         relations = self.model.relations[REDIS_REL_NAME]
         if relations:
             for relation in relations:
-                relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.current_master)
+                relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
+                    self.current_master
+                )
             if self._peers.data[self.unit].get("upgrading", "false") == "true":
                 self._peers.data[self.unit]["upgrading"] = ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from tests.helpers import NUM_UNITS
+
+
+def pytest_addoption(parser):
+    """Parse additional pytest options."""
+    parser.addoption("--num-units", action="store", type=int, default=NUM_UNITS)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -251,6 +251,7 @@ class TestCharm(TestCase):
         # After adding them, check that the property returns paths for the three of them
         self.assertTrue(None not in self.harness.charm._certificates)
 
+        self.harness.set_leader(True)
         self.harness.charm.on.upgrade_charm.emit()
         _store_certificates.assert_called()
 

--- a/tox.ini
+++ b/tox.ini
@@ -120,6 +120,7 @@ deps =
     # This is needed because of https://github.com/juju/python-libjuju/pull/698
     juju==2.9.11
     pytest-operator
+    lightkube==0.10.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}/integration/test_redis_relation.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0


### PR DESCRIPTION
## Issue

When the Redis charm pod was restarted by Kubernetes in a single unit deployment. The relation data will not update after the pod IP is changed. This is discovered during yesterday's indico incident.

## Solution
Update the relation data when the charm detected that it's in a single unit deployment in the `upgrade-charm` event handler.

Also, fix some potential problems which may occur when there is more than one redis relation attached to a single redis charm application.

## Testing
Add some integration tests for this situation.
