### PR TITLE
Move charmed-redis OCI from DockerHub to GitHub Container Registry

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@ It connects to a controller. The controller is hosted on a cloud and controls mo
 Then you build and deploy this charm into the model you just created:
     
     charmcraft pack
-    juju deploy ./redis-k8s_ubuntu-20.04-amd64.charm --resource redis-image=dataplatformoci/redis:7.0-22.04_edge
+    juju deploy ./redis-k8s_ubuntu-20.04-amd64.charm --resource redis-image=ghcr.io/canonical/charmed-redis:7.0-22.04_edge
 
 Once Redis starts up it will be running on its default port, 6379. 
 To check it you run:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,7 +44,7 @@ resources:
   redis-image:
     type: oci-image
     description: ubuntu lts docker image for redis
-    upstream: dataplatformoci/redis:7.0-22.04_edge
+    upstream: ghcr.io/canonical/charmed-redis:7.0-22.04_edge
   cert-file:
     type: file
     filename: redis.crt


### PR DESCRIPTION
## Issue
Docker is sunsetting Free Team organizations.
We have to stop using "Docker Free Team”: https://hub.docker.com/r/dataplatformoci/redis

## Solution
Closes: https://warthogs.atlassian.net/browse/DPE-1562
Move to GitHub Container Registry.