### PR TITLE
[DPE-2097] Trigger relation changed when pod get restarted

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -89,7 +89,7 @@ class RedisK8sCharm(CharmBase):
         # The IP might change, so the data needs to be propagated
         for relation in self.model.relations[REDIS_REL_NAME]:
             relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
-                self.unit_pod_hostname
+                self.current_master
             )
 
     def _upgrade_charm(self, event: UpgradeCharmEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,9 +88,7 @@ class RedisK8sCharm(CharmBase):
         # In the event of a pod restart on the same node the upgrade event is not fired.
         # The IP might change, so the data needs to be propagated
         for relation in self.model.relations[REDIS_REL_NAME]:
-            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
-                self.current_master
-            )
+            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.current_master)
 
     def _upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         """Handle the upgrade_charm event.

--- a/src/charm.py
+++ b/src/charm.py
@@ -85,6 +85,12 @@ class RedisK8sCharm(CharmBase):
         if not isinstance(self.unit.status, ActiveStatus):
             event.defer()
             return
+        # In the event of a pod restart on the same node the upgrade event is not fired.
+        # The IP might change, so the data needs to be propagated
+        for relation in self.model.relations[REDIS_REL_NAME]:
+            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
+                self.unit_pod_hostname
+            )
 
     def _upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         """Handle the upgrade_charm event.

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -61,7 +61,10 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME, series="focal"
             ),
             ops_test.model.deploy(
-                POSTGRESQL_APP_NAME, application_name=POSTGRESQL_APP_NAME, series="focal"
+                POSTGRESQL_APP_NAME,
+                application_name=POSTGRESQL_APP_NAME,
+                channel="latest/stable",
+                series="focal",
             ),
         )
         await ops_test.model.wait_for_idle(

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -60,7 +60,12 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
             ops_test.model.deploy(
                 FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME, series="focal"
             ),
-            ops_test.model.deploy(POSTGRESQL_APP_NAME, application_name=POSTGRESQL_APP_NAME),
+            ops_test.model.deploy(
+                POSTGRESQL_APP_NAME,
+                application_name=POSTGRESQL_APP_NAME,
+                channel="latest/edge",
+                series="focal",
+            ),
         )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, POSTGRESQL_APP_NAME], status="active", timeout=3000

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -60,12 +60,7 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
             ops_test.model.deploy(
                 FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME, series="focal"
             ),
-            ops_test.model.deploy(
-                POSTGRESQL_APP_NAME,
-                application_name=POSTGRESQL_APP_NAME,
-                channel="latest/stable",
-                series="focal",
-            ),
+            ops_test.model.deploy(POSTGRESQL_APP_NAME, application_name=POSTGRESQL_APP_NAME),
         )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME, POSTGRESQL_APP_NAME], status="active", timeout=3000


### PR DESCRIPTION
In the event of a pod restart on the same node the upgrade event is not fired. The IP might change, so the data needs to be propagated