### PR TITLE
[DPE-2097] Fix integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.43"
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration-scaling

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-charm
 
@@ -57,8 +56,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation
 
@@ -75,8 +73,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation -- --num-units 1
 
@@ -93,8 +90,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-password
 
@@ -111,7 +107,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-scaling

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-ops~=1.5.0
+ops~=2.3.0
 redis~=4.3.4
 jinja2==3.1.1
 tenacity==8.0.1

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -144,8 +144,7 @@ async def test_delete_redis_pod(ops_test: OpsTest):
     )
 
     redis_ip_after = await get_address(ops_test, app_name=APP_NAME, unit_num=leader_unit_num)
-    # discourse restarted, unit_num += 1
-    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME, unit_num=1)
+    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = query_url(url)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -146,6 +146,7 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
         timeout=60,
     )
     assert last_redis.execute_command("ROLE")[0] == "master"
+    sentinel.close()
     last_redis.close()
 
     # SCALE DOWN #
@@ -158,6 +159,10 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
         assert client.get("testKey") == b"myValue"
         client.close()
 
+    address = await get_address(ops_test, unit_num=0)
+    sentinel = Redis(address, port=26379, password=sentinel_password, decode_responses=True)
+    sentinel.execute_command(f"SENTINEL RESET {APP_NAME}")
+    time.sleep(10)
     master_info = sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
     master_info = dict(zip(master_info[::2], master_info[1::2]))
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -146,7 +146,6 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
         timeout=60,
     )
     assert last_redis.execute_command("ROLE")[0] == "master"
-    sentinel.close()
     last_redis.close()
 
     # SCALE DOWN #
@@ -159,10 +158,6 @@ async def test_scale_down_departing_master(ops_test: OpsTest):
         assert client.get("testKey") == b"myValue"
         client.close()
 
-    address = await get_address(ops_test, unit_num=0)
-    sentinel = Redis(address, port=26379, password=sentinel_password, decode_responses=True)
-    sentinel.execute_command(f"SENTINEL RESET {APP_NAME}")
-    time.sleep(10)
     master_info = sentinel.execute_command(f"SENTINEL MASTER {APP_NAME}")
     master_info = dict(zip(master_info[::2], master_info[1::2]))
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,6 +28,8 @@ class TestCharm(TestCase):
 
         self.harness = Harness(RedisK8sCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_can_connect("redis", True)
+        self.harness.set_can_connect("sentinel", True)
         self.harness.begin()
         self.harness.add_relation(self._peer_relation, self.harness.charm.app.name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -69,11 +69,10 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    # This is needed because of https://github.com/juju/python-libjuju/pull/698
-    juju==2.9.11
+    juju==2.9.42.4
     pytest-operator
     pytest-order
-    lightkube==0.10.0
+    lightkube==0.13.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0
@@ -82,10 +81,9 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    # This is needed because of https://github.com/juju/python-libjuju/pull/698
-    juju==2.9.11
+    juju==2.9.42.4
     pytest-operator
-    lightkube==0.10.0
+    lightkube==0.13.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}/integration/test_charm.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0
@@ -94,8 +92,7 @@ commands =
 description = Run scaling integration tests
 deps =
     pytest
-    # This is needed because of https://github.com/juju/python-libjuju/pull/698
-    juju==2.9.11
+    juju==2.9.42.4
     pytest-operator
     pytest-order
     -r{toxinidir}/requirements.txt
@@ -106,8 +103,7 @@ commands =
 description = Run password integration tests
 deps =
     pytest
-    # This is needed because of https://github.com/juju/python-libjuju/pull/698
-    juju==2.9.11
+    juju==2.9.42.4
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
@@ -117,10 +113,9 @@ commands =
 description = Run integration tests for redis relation
 deps =
     pytest
-    # This is needed because of https://github.com/juju/python-libjuju/pull/698
-    juju==2.9.11
+    juju==2.9.42.4
     pytest-operator
-    lightkube==0.10.0
+    lightkube==0.13.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest {[vars]tst_path}/integration/test_redis_relation.py -vv --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0


### PR DESCRIPTION
Fix integration tests.

Postgresql channel needs to be changed once https://github.com/canonical/postgresql-operator/pull/139 is merged and released

1) Postgresql channel `latest/stable` can't be deployed on agent version `2.9.29`
2) Redis scale down only works on agent version <=`2.9.42` and integration tests need to be pinned on `2.9.29`

For the two reasons above, I've changed the agents depending on the tests. I'll add an issue to fix scale down implementation for agent > `2.9.42`