### PR TITLE
Replace current_master for current_primary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-charm
 
@@ -56,7 +55,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation
 
@@ -73,7 +71,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation -- --num-units 1
 
@@ -90,7 +87,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-password
 
@@ -107,6 +103,5 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration-scaling

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-charm
 
@@ -56,7 +56,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation
 
@@ -73,7 +73,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-relation -- --num-units 1
 
@@ -90,7 +90,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version 2.9.43"
       - name: Run integration tests
         run: tox -e integration-password
 
@@ -107,6 +107,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.28-strict/stable
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration-scaling

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e integration-charm
 
@@ -55,6 +56,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e integration-relation
 
@@ -71,6 +73,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e integration-relation -- --num-units 1
 
@@ -87,6 +90,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e integration-password
 
@@ -103,5 +107,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          channel: 1.28-strict/stable
       - name: Run integration tests
         run: tox -e integration-scaling

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -132,7 +132,7 @@ class RedisProvides(Object):
 
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
-        event.relation.data[self.model.unit]["hostname"] = self._get_main_ip()
+        event.relation.data[self.model.unit]["hostname"] = self._get_primary_ip()
         event.relation.data[self.model.unit]["port"] = str(self._port)
         # The reactive Redis charm also exposes 'password'. When tackling
         # https://github.com/canonical/redis-k8s/issues/7 add 'password'
@@ -146,6 +146,6 @@ class RedisProvides(Object):
             return address
         return self.app.name
 
-    def _get_main_ip(self) -> str:
-        """Gets the ip of the current redis main process."""
+    def _get_primary_ip(self) -> str:
+        """Gets the ip of the current redis primary process."""
         return socket.gethostbyname(self._charm.current_primary)

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -148,4 +148,4 @@ class RedisProvides(Object):
 
     def _get_main_ip(self) -> str:
         """Gets the ip of the current redis main process."""
-        return socket.gethostbyname(self._charm.current_main)
+        return socket.gethostbyname(self._charm.current_primary)

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -132,7 +132,7 @@ class RedisProvides(Object):
 
     def _on_relation_changed(self, event):
         """Handle the relation changed event."""
-        event.relation.data[self.model.unit]["hostname"] = self._get_master_ip()
+        event.relation.data[self.model.unit]["hostname"] = self._get_main_ip()
         event.relation.data[self.model.unit]["port"] = str(self._port)
         # The reactive Redis charm also exposes 'password'. When tackling
         # https://github.com/canonical/redis-k8s/issues/7 add 'password'
@@ -146,6 +146,6 @@ class RedisProvides(Object):
             return address
         return self.app.name
 
-    def _get_master_ip(self) -> str:
-        """Gets the ip of the current redis master."""
-        return socket.gethostbyname(self._charm.current_master)
+    def _get_main_ip(self) -> str:
+        """Gets the ip of the current redis main process."""
+        return socket.gethostbyname(self._charm.current_main)

--- a/src/charm.py
+++ b/src/charm.py
@@ -352,7 +352,7 @@ class RedisK8sCharm(CharmBase):
         extra_flags = [
             f"--requirepass {self._get_password()}",
             "--bind 0.0.0.0",
-            f"--primaryauth {self._get_password()}",
+            f"--masterauth {self._get_password()}",
             f"--replica-announce-ip {self.unit_pod_hostname}",
         ]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,13 +88,13 @@ class RedisK8sCharm(CharmBase):
         # In the event of a pod restart on the same node the upgrade event is not fired.
         # The IP might change, so the data needs to be propagated
         for relation in self.model.relations[REDIS_REL_NAME]:
-            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.current_main)
+            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.current_primary)
 
     def _upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         """Handle the upgrade_charm event.
 
         Check for failover status and update connection information for redis relation and
-        current_main.
+        current_primary.
         Also tries to store the certificates on the redis container, as new `juju attach-resource`
         will trigger this event.
         """
@@ -150,10 +150,10 @@ class RedisK8sCharm(CharmBase):
         if not self.get_sentinel_password():
             logger.info("Creating sentinel password")
             self._peers.data[self.app][SENTINEL_PASSWORD_KEY] = self._generate_password()
-        # NOTE: if current_main is not set yet, the application is being deployed for the
+        # NOTE: if current_primary is not set yet, the application is being deployed for the
         # first time. Otherwise, we check for failover in case previous juju leader was redis
         # master as well.
-        if self.current_main is None:
+        if self.current_primary is None:
             logger.info(
                 "Initial replication, setting leader-host to {}".format(self.unit_pod_hostname)
             )
@@ -224,7 +224,7 @@ class RedisK8sCharm(CharmBase):
         if relations:
             for relation in relations:
                 relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
-                    self.current_main
+                    self.current_primary
                 )
             if self._peers.data[self.unit].get("upgrading", "false") == "true":
                 self._peers.data[self.unit]["upgrading"] = ""
@@ -377,8 +377,8 @@ class RedisK8sCharm(CharmBase):
             ]
 
         # Check that current unit is master
-        if self.current_main != self.unit_pod_hostname:
-            extra_flags += [f"--replicaof {self.current_main} {REDIS_PORT}"]
+        if self.current_primary != self.unit_pod_hostname:
+            extra_flags += [f"--replicaof {self.current_primary} {REDIS_PORT}"]
 
             if self.config["enable-tls"]:
                 extra_flags += ["--tls-replication yes"]
@@ -455,7 +455,7 @@ class RedisK8sCharm(CharmBase):
         return socket.getfqdn(name)
 
     @property
-    def current_main(self) -> Optional[str]:
+    def current_primary(self) -> Optional[str]:
         """Get the current master."""
         return self._peers.data[self.app].get(LEADER_HOST_KEY)
 
@@ -472,7 +472,7 @@ class RedisK8sCharm(CharmBase):
         if self._peers.data[self.app].get("enable-password", "true") == "false":
             password = True
 
-        return bool(password and self.current_main)
+        return bool(password and self.current_primary)
 
     def _generate_password(self) -> str:
         """Generate a random 16 character password string.
@@ -583,7 +583,7 @@ class RedisK8sCharm(CharmBase):
         info = self.sentinel.get_master_info(host=host)
         if info is None:
             return False
-        elif (info["ip"] == self.current_main) and ("s_down" not in info["flags"]):
+        elif (info["ip"] == self.current_primary) and ("s_down" not in info["flags"]):
             return True
 
         return False
@@ -605,7 +605,7 @@ class RedisK8sCharm(CharmBase):
         This method should only be called from juju leader, to avoid more than one
         sentinel sending failovers concurrently.
         """
-        if self._k8s_hostname(departing_unit_name) != self.current_main:
+        if self._k8s_hostname(departing_unit_name) != self.current_primary:
             # No failover needed
             return
 

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -110,7 +110,7 @@ class Sentinel(Object):
             hostname=self.charm.unit_pod_hostname,
             master_name=self.charm._name,
             sentinel_port=SENTINEL_PORT,
-            redis_master=self.charm.current_main,
+            redis_master=self.charm.current_primary,
             redis_port=REDIS_PORT,
             quorum=self.expected_quorum,
             master_password=self.charm._get_password(),

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -110,7 +110,7 @@ class Sentinel(Object):
             hostname=self.charm.unit_pod_hostname,
             master_name=self.charm._name,
             sentinel_port=SENTINEL_PORT,
-            redis_master=self.charm.current_master,
+            redis_master=self.charm.current_main,
             redis_port=REDIS_PORT,
             quorum=self.expected_quorum,
             master_password=self.charm._get_password(),

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -152,7 +152,7 @@ class Sentinel(Object):
         with self.sentinel_client(host) as sentinel:
             try:
                 # get sentinel info about the primary
-                primary_info = sentinel.execute_command(f"SENTINEL primary {self.charm._name}")
+                primary_info = sentinel.execute_command(f"SENTINEL MASTER {self.charm._name}")
 
                 # NOTE: primary info from redis comes like a list:
                 # ['key1', 'value1', 'key2', 'value2', ...]

--- a/templates/sentinel.conf.j2
+++ b/templates/sentinel.conf.j2
@@ -1,11 +1,11 @@
 port {{ sentinel_port }}
-sentinel monitor {{ master_name }} {{ redis_master }} {{ redis_port }} {{ quorum }}
-sentinel down-after-milliseconds {{ master_name }} 5000
-sentinel failover-timeout {{ master_name }} 30000
-sentinel parallel-syncs {{ master_name }} 1
+sentinel monitor {{ primary_name }} {{ redis_primary }} {{ redis_port }} {{ quorum }}
+sentinel down-after-milliseconds {{ primary_name }} 5000
+sentinel failover-timeout {{ primary_name }} 30000
+sentinel parallel-syncs {{ primary_name }} 1
 
-{% if master_password != None %}
-sentinel auth-pass {{ master_name }} {{ master_password }}
+{% if primary_password != None %}
+sentinel auth-pass {{ primary_name }} {{ primary_password }}
 {% endif %}
 requirepass {{ sentinel_password }}
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -113,7 +113,7 @@ async def test_sentinels_expected(ops_test: OpsTest):
     logger.info("retrieved sentinel password for %s: %s", APP_NAME, password)
 
     sentinel = Redis(address, password=password, port=26379)
-    sentinels_connected = sentinel.info("sentinel")["primary0"]["sentinels"]
+    sentinels_connected = sentinel.info("sentinel")["master0"]["sentinels"]
 
     assert sentinels_connected == NUM_UNITS
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -113,7 +113,7 @@ async def test_sentinels_expected(ops_test: OpsTest):
     logger.info("retrieved sentinel password for %s: %s", APP_NAME, password)
 
     sentinel = Redis(address, password=password, port=26379)
-    sentinels_connected = sentinel.info("sentinel")["master0"]["sentinels"]
+    sentinels_connected = sentinel.info("sentinel")["primary0"]["sentinels"]
 
     assert sentinels_connected == NUM_UNITS
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -197,11 +197,11 @@ class TestCharm(TestCase):
             admin_password,
         )
 
-    @mock.patch.object(RedisProvides, "_get_master_ip")
-    def test_on_relation_changed_status_when_unit_is_leader(self, get_master_ip):
+    @mock.patch.object(RedisProvides, "_get_main_ip")
+    def test_on_relation_changed_status_when_unit_is_leader(self, get_main_ip):
         # Given
         self.harness.set_leader(True)
-        get_master_ip.return_value = "10.2.1.5"
+        get_main_ip.return_value = "10.2.1.5"
 
         rel_id = self.harness.add_relation("redis", "wordpress")
         self.harness.add_relation_unit(rel_id, "wordpress/0")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -86,7 +86,7 @@ class TestCharm(TestCase):
         extra_flags = [
             f"--requirepass {self.harness.charm._get_password()}",
             "--bind 0.0.0.0",
-            f"--primaryauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm._get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
         ]
         expected_plan = {
@@ -118,7 +118,7 @@ class TestCharm(TestCase):
         extra_flags = [
             f"--requirepass {self.harness.charm._get_password()}",
             "--bind 0.0.0.0",
-            f"--primaryauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm._get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
         ]
         expected_plan = {
@@ -283,7 +283,7 @@ class TestCharm(TestCase):
         extra_flags = [
             f"--requirepass {self.harness.charm._get_password()}",
             "--bind 0.0.0.0",
-            f"--primaryauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm._get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             "--tls-port 6379",
             "--port 0",
@@ -319,11 +319,11 @@ class TestCharm(TestCase):
         def my_side_effect(value: str):
             mapping = {
                 f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL primary {self.harness.charm._name}": [
+                f"SENTINEL MASTER {self.harness.charm._name}": [
                     "ip",
                     APPLICATION_DATA["leader-host"],
                     "flags",
-                    "primary",
+                    "master",
                 ],
             }
             return mapping.get(value)
@@ -343,7 +343,7 @@ class TestCharm(TestCase):
         extra_flags = [
             f"--requirepass {self.harness.charm._get_password()}",
             "--bind 0.0.0.0",
-            f"--primaryauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm._get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             f"--replicaof {leader_hostname} {redis_port}",
         ]
@@ -370,7 +370,7 @@ class TestCharm(TestCase):
         def my_side_effect(value: str):
             mapping = {
                 f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL primary {self.harness.charm._name}": [
+                f"SENTINEL MASTER {self.harness.charm._name}": [
                     "ip",
                     "different-leader",
                     "flags",
@@ -389,7 +389,7 @@ class TestCharm(TestCase):
         self.harness.update_relation_data(rel.id, "redis-k8s", APPLICATION_DATA)
 
         # NOTE: On config changed, charm will be updated with APPLICATION_DATA. But a
-        # call to `execute_command(SENTINEL primary redis-k8s)` will return `different_leader`
+        # call to `execute_command(SENTINEL MASTER redis-k8s)` will return `different_leader`
         # when checking the primary, simulating that sentinel triggered failover in between
         # charm events.
         self.harness._emit_relation_changed(rel.id, "redis-k8s")
@@ -412,11 +412,11 @@ class TestCharm(TestCase):
         def my_side_effect(value: str):
             mapping = {
                 f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL primary {self.harness.charm._name}": [
+                f"SENTINEL MASTER {self.harness.charm._name}": [
                     "ip",
                     self.harness.charm._k8s_hostname("redis-k8s/1"),
                     "flags",
-                    "primary",
+                    "master",
                 ],
             }
             return mapping.get(value)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -197,11 +197,11 @@ class TestCharm(TestCase):
             admin_password,
         )
 
-    @mock.patch.object(RedisProvides, "_get_main_ip")
-    def test_on_relation_changed_status_when_unit_is_leader(self, get_main_ip):
+    @mock.patch.object(RedisProvides, "_get_primary_ip")
+    def test_on_relation_changed_status_when_unit_is_leader(self, get_primary_ip):
         # Given
         self.harness.set_leader(True)
-        get_main_ip.return_value = "10.2.1.5"
+        get_primary_ip.return_value = "10.2.1.5"
 
         rel_id = self.harness.add_relation("redis", "wordpress")
         self.harness.add_relation_unit(rel_id, "wordpress/0")


### PR DESCRIPTION
## Issue
Charms using the Redis library that check for inclusive naming fail because of the word "master".

## Solution
Replace current_master for current_primary
