### PR TITLE
Added workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Redis Operator
+[![Charmhub](https://charmhub.io/redis-k8s/badge.svg)](https://charmhub.io/redis-k8s)
 [![Release to latest/edge](https://github.com/canonical/redis-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/redis-k8s-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/redis-k8s-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/redis-k8s-operator/actions/workflows/ci.yaml)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Redis Operator
+[![Release to latest/edge](https://github.com/canonical/redis-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/redis-k8s-operator/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/redis-k8s-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/redis-k8s-operator/actions/workflows/ci.yaml)
 
 A Juju charm deploying and managing Redis on Kubernetes.
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for

- CharmHub Badge
- Release
- Tests