### PR TITLE
[DPE-4523] create new resource revision for redis-image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.1.1
         with:
-          resource-overrides: "redis-image:3"
+          resource-overrides: "redis-image:4"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"


### PR DESCRIPTION
## Issue
Request from @mthaddon: `Could the charm be released with the image resource it needs so we don't have a manually specify it?`

## Solution
Increase resource revision to provide new redis image as resource connected to the charm in charmhub.