### PR TITLE
advertise ip address of each unit, not just the current master

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -112,7 +112,9 @@ class RedisK8sCharm(CharmBase):
         # In the event of a pod restart on the same node the upgrade event is not fired.
         # The IP might change, so the data needs to be propagated
         for relation in self.model.relations[REDIS_REL_NAME]:
-            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(self.current_master)
+            relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
+                self.unit_pod_hostname
+            )
 
     def _upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         """Handle the upgrade_charm event.
@@ -248,7 +250,7 @@ class RedisK8sCharm(CharmBase):
         if relations:
             for relation in relations:
                 relation.data[self.model.unit]["hostname"] = socket.gethostbyname(
-                    self.current_master
+                    self.unit_pod_hostname
                 )
             if self._peers.data[self.unit].get("upgrading", "false") == "true":
                 self._peers.data[self.unit]["upgrading"] = ""


### PR DESCRIPTION
## Issue
https://github.com/canonical/redis-k8s-operator/issues/84

## Solution
Advertise ip address of each deployed unit, not just the current master.