### PR TITLE
[DPE-4808] Update integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,8 @@ jobs:
         tox-environments:
           - integration-charm
           - integration-password
-          - integration-redis-relation
+          # reason: "https://github.com/canonical/discourse-k8s-operator/issues/268"
+          # - integration-redis-relation
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,8 @@ jobs:
         tox-environments:
           - integration-charm
           - integration-password
-          # reason: "https://github.com/canonical/discourse-k8s-operator/issues/268"
+          # Skipping until issues in `discourse-k8s-operator` are resolved. Issue:
+          # "https://github.com/canonical/discourse-k8s-operator/issues/268"
           # - integration-redis-relation
     name: ${{ matrix.tox-environments }}
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.1.1
         with:
-          resource-overrides: "redis-image:4"
+          resource-overrides: "redis-image:5"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -155,6 +155,9 @@ async def test_delete_redis_pod(ops_test: OpsTest):
     assert response.status == 200
 
 
+@pytest.mark.skip(
+    reason="This charm is no longer maintained, see https://chat.canonical.com/canonical/pl/awnyrhtc5fb4pxpqjsyxc59xae"
+)
 async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
     """Test the second Discourse charm."""
     unit_map = await get_unit_map(ops_test)

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -60,7 +60,7 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 DISCOURSE_APP_NAME,
                 application_name=DISCOURSE_APP_NAME,
                 series="focal",
-                channel="latest/edge",
+                channel="latest/stable",
             ),
             ops_test.model.deploy(
                 POSTGRESQL_APP_NAME,

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -57,7 +57,10 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 series="focal",
             ),
             ops_test.model.deploy(
-                DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME, series="focal"
+                DISCOURSE_APP_NAME,
+                application_name=DISCOURSE_APP_NAME,
+                series="focal",
+                channel="latest/edge",
             ),
             ops_test.model.deploy(
                 POSTGRESQL_APP_NAME,

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -16,12 +16,10 @@ from .helpers import (
     check_application_status,
     get_address,
     get_unit_map,
-    get_unit_number,
     query_url,
 )
 
-FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
-SECOND_DISCOURSE_APP_NAME = "discourse-charmers-discourse-k8s"
+DISCOURSE_APP_NAME = "discourse-k8s"
 POSTGRESQL_APP_NAME = "postgresql-k8s"
 
 logger = logging.getLogger(__name__)
@@ -59,7 +57,10 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 series="focal",
             ),
             ops_test.model.deploy(
-                FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME, series="focal"
+                DISCOURSE_APP_NAME,
+                application_name=DISCOURSE_APP_NAME,
+                series="focal",
+                channel="latest/stable",
             ),
             ops_test.model.deploy(
                 POSTGRESQL_APP_NAME,
@@ -74,12 +75,10 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
         )
         # Discourse becomes blocked waiting for relations.
         await ops_test.model.wait_for_idle(
-            apps=[FIRST_DISCOURSE_APP_NAME], status="waiting", idle_period=20, timeout=3000
+            apps=[DISCOURSE_APP_NAME], status="waiting", idle_period=20, timeout=3000
         )
 
-    assert (
-        ops_test.model.applications[FIRST_DISCOURSE_APP_NAME].units[0].workload_status == "waiting"
-    )
+    assert ops_test.model.applications[DISCOURSE_APP_NAME].units[0].workload_status == "waiting"
     assert ops_test.model.applications[POSTGRESQL_APP_NAME].units[0].workload_status == "active"
 
 
@@ -88,14 +87,14 @@ async def test_discourse_relation(ops_test: OpsTest):
     # Test the first Discourse charm.
     # Add both relations to Discourse (PostgreSQL and Redis)
     # and wait for it to be ready.
-    await ops_test.model.relate(f"{POSTGRESQL_APP_NAME}:database", FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(f"{POSTGRESQL_APP_NAME}:database", DISCOURSE_APP_NAME)
     # Wait until discourse handles all relation events related to postgresql
-    await ops_test.model.relate(APP_NAME, FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(APP_NAME, DISCOURSE_APP_NAME)
 
     # This won't work: model.applications[app_name].units[0].workload_status returns wrong status
     """
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, FIRST_DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
+        apps=[APP_NAME, DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
         status="active",
         idle_period=30,
         timeout=3000,  # Discourse takes a longer time to become active (a lot of setup).
@@ -103,7 +102,7 @@ async def test_discourse_relation(ops_test: OpsTest):
     """
 
     await ops_test.model.block_until(
-        lambda: check_application_status(ops_test, FIRST_DISCOURSE_APP_NAME) == "active",
+        lambda: check_application_status(ops_test, DISCOURSE_APP_NAME) == "active",
         timeout=900,
         wait_period=5,
     )
@@ -116,7 +115,7 @@ async def test_discourse_relation(ops_test: OpsTest):
 
 async def test_discourse_request(ops_test: OpsTest):
     """Try to connect to discourse after the bundle is deployed."""
-    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
+    discourse_ip = await get_address(ops_test, app_name=DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = query_url(url)
 
@@ -141,55 +140,15 @@ async def test_delete_redis_pod(ops_test: OpsTest):
         apps=[APP_NAME], status="active", timeout=1000, idle_period=60
     )
     await ops_test.model.block_until(
-        lambda: check_application_status(ops_test, FIRST_DISCOURSE_APP_NAME) == "active",
+        lambda: check_application_status(ops_test, DISCOURSE_APP_NAME) == "active",
         timeout=1200,
         wait_period=5,
     )
 
     redis_ip_after = await get_address(ops_test, app_name=APP_NAME, unit_num=leader_unit_num)
-    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
+    discourse_ip = await get_address(ops_test, app_name=DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = query_url(url)
 
     assert redis_ip_before != redis_ip_after
     assert response.status == 200
-
-
-@pytest.mark.skip(
-    reason="This charm is no longer maintained, see https://chat.canonical.com/canonical/pl/awnyrhtc5fb4pxpqjsyxc59xae"
-)
-async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
-    """Test the second Discourse charm."""
-    unit_map = await get_unit_map(ops_test)
-
-    # Get the Redis instance IP address.
-    redis_host = await get_address(ops_test, unit_num=get_unit_number(unit_map["leader"]))
-
-    # Deploy Discourse and wait for it to be blocked waiting for database relation.
-    await ops_test.model.deploy(
-        SECOND_DISCOURSE_APP_NAME,
-        application_name=SECOND_DISCOURSE_APP_NAME,
-        config={
-            "redis_host": redis_host,
-            "developer_emails": "user@foo.internal",
-            "external_hostname": "foo.internal",
-            "smtp_address": "127.0.0.1",
-            "smtp_domain": "foo.internal",
-        },
-        series="focal",
-    )
-    # Discourse becomes blocked waiting for PostgreSQL relation.
-    await ops_test.model.wait_for_idle(
-        apps=[SECOND_DISCOURSE_APP_NAME], status="blocked", timeout=3000
-    )
-
-    # Relate PostgreSQL and Discourse, waiting for Discourse to be ready.
-    await ops_test.model.add_relation(
-        f"{POSTGRESQL_APP_NAME}:db-admin",
-        SECOND_DISCOURSE_APP_NAME,
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRESQL_APP_NAME, SECOND_DISCOURSE_APP_NAME, APP_NAME],
-        status="active",
-        timeout=3000,  # Discourse takes a longer time to become active (a lot of setup).
-    )

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -16,12 +16,10 @@ from .helpers import (
     check_application_status,
     get_address,
     get_unit_map,
-    get_unit_number,
     query_url,
 )
 
-FIRST_DISCOURSE_APP_NAME = "discourse-k8s"
-SECOND_DISCOURSE_APP_NAME = "discourse-charmers-discourse-k8s"
+DISCOURSE_APP_NAME = "discourse-k8s"
 POSTGRESQL_APP_NAME = "postgresql-k8s"
 
 logger = logging.getLogger(__name__)
@@ -59,7 +57,7 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 series="focal",
             ),
             ops_test.model.deploy(
-                FIRST_DISCOURSE_APP_NAME, application_name=FIRST_DISCOURSE_APP_NAME, series="focal"
+                DISCOURSE_APP_NAME, application_name=DISCOURSE_APP_NAME, series="focal"
             ),
             ops_test.model.deploy(
                 POSTGRESQL_APP_NAME,
@@ -74,12 +72,10 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
         )
         # Discourse becomes blocked waiting for relations.
         await ops_test.model.wait_for_idle(
-            apps=[FIRST_DISCOURSE_APP_NAME], status="waiting", idle_period=20, timeout=3000
+            apps=[DISCOURSE_APP_NAME], status="waiting", idle_period=20, timeout=3000
         )
 
-    assert (
-        ops_test.model.applications[FIRST_DISCOURSE_APP_NAME].units[0].workload_status == "waiting"
-    )
+    assert ops_test.model.applications[DISCOURSE_APP_NAME].units[0].workload_status == "waiting"
     assert ops_test.model.applications[POSTGRESQL_APP_NAME].units[0].workload_status == "active"
 
 
@@ -88,14 +84,14 @@ async def test_discourse_relation(ops_test: OpsTest):
     # Test the first Discourse charm.
     # Add both relations to Discourse (PostgreSQL and Redis)
     # and wait for it to be ready.
-    await ops_test.model.relate(f"{POSTGRESQL_APP_NAME}:database", FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(f"{POSTGRESQL_APP_NAME}:database", DISCOURSE_APP_NAME)
     # Wait until discourse handles all relation events related to postgresql
-    await ops_test.model.relate(APP_NAME, FIRST_DISCOURSE_APP_NAME)
+    await ops_test.model.relate(APP_NAME, DISCOURSE_APP_NAME)
 
     # This won't work: model.applications[app_name].units[0].workload_status returns wrong status
     """
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, FIRST_DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
+        apps=[APP_NAME, DISCOURSE_APP_NAME, POSTGRESQL_APP_NAME],
         status="active",
         idle_period=30,
         timeout=3000,  # Discourse takes a longer time to become active (a lot of setup).
@@ -103,7 +99,7 @@ async def test_discourse_relation(ops_test: OpsTest):
     """
 
     await ops_test.model.block_until(
-        lambda: check_application_status(ops_test, FIRST_DISCOURSE_APP_NAME) == "active",
+        lambda: check_application_status(ops_test, DISCOURSE_APP_NAME) == "active",
         timeout=900,
         wait_period=5,
     )
@@ -116,7 +112,7 @@ async def test_discourse_relation(ops_test: OpsTest):
 
 async def test_discourse_request(ops_test: OpsTest):
     """Try to connect to discourse after the bundle is deployed."""
-    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
+    discourse_ip = await get_address(ops_test, app_name=DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = query_url(url)
 
@@ -141,52 +137,15 @@ async def test_delete_redis_pod(ops_test: OpsTest):
         apps=[APP_NAME], status="active", timeout=1000, idle_period=60
     )
     await ops_test.model.block_until(
-        lambda: check_application_status(ops_test, FIRST_DISCOURSE_APP_NAME) == "active",
+        lambda: check_application_status(ops_test, DISCOURSE_APP_NAME) == "active",
         timeout=1200,
         wait_period=5,
     )
 
     redis_ip_after = await get_address(ops_test, app_name=APP_NAME, unit_num=leader_unit_num)
-    discourse_ip = await get_address(ops_test, app_name=FIRST_DISCOURSE_APP_NAME)
+    discourse_ip = await get_address(ops_test, app_name=DISCOURSE_APP_NAME)
     url = f"http://{discourse_ip}:3000/site.json"
     response = query_url(url)
 
     assert redis_ip_before != redis_ip_after
     assert response.status == 200
-
-
-async def test_discourse_from_discourse_charmers(ops_test: OpsTest):
-    """Test the second Discourse charm."""
-    unit_map = await get_unit_map(ops_test)
-
-    # Get the Redis instance IP address.
-    redis_host = await get_address(ops_test, unit_num=get_unit_number(unit_map["leader"]))
-
-    # Deploy Discourse and wait for it to be blocked waiting for database relation.
-    await ops_test.model.deploy(
-        SECOND_DISCOURSE_APP_NAME,
-        application_name=SECOND_DISCOURSE_APP_NAME,
-        config={
-            "redis_host": redis_host,
-            "developer_emails": "user@foo.internal",
-            "external_hostname": "foo.internal",
-            "smtp_address": "127.0.0.1",
-            "smtp_domain": "foo.internal",
-        },
-        series="focal",
-    )
-    # Discourse becomes blocked waiting for PostgreSQL relation.
-    await ops_test.model.wait_for_idle(
-        apps=[SECOND_DISCOURSE_APP_NAME], status="blocked", timeout=3000
-    )
-
-    # Relate PostgreSQL and Discourse, waiting for Discourse to be ready.
-    await ops_test.model.add_relation(
-        f"{POSTGRESQL_APP_NAME}:db-admin",
-        SECOND_DISCOURSE_APP_NAME,
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRESQL_APP_NAME, SECOND_DISCOURSE_APP_NAME, APP_NAME],
-        status="active",
-        timeout=3000,  # Discourse takes a longer time to become active (a lot of setup).
-    )


### PR DESCRIPTION
## Issue
1. The integration tests for relating redis to the `discourse-charmers-discourse-k8s` charm fail.
2. The integration test for relation redis (with multiple units) to `discourse-k8s` also fail (because of an issue on their side: https://github.com/canonical/discourse-k8s-operator/issues/268)

## Solution
1. After confirming with IS DevOps Team, these tests can be removed as this charm is no longer maintained. The charm `discourse-k8s` is not impacted, tests for this charm need to stay.
2. This integration test is temporarily skipped, until the issue is resolved.