### PR TITLE
[DPE-4808] Initialize directory structure on startup

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -337,6 +337,15 @@ class RedisK8sCharm(CharmBase):
                 group=REDIS_USER,
             )
 
+        if not container.exists(WORKING_DIR):
+            container.make_dir(
+                WORKING_DIR,
+                make_parents=True,
+                permissions=0o770,
+                user=REDIS_USER,
+                group=REDIS_USER,
+            )
+
         if not self._valid_app_databag():
             self.unit.status = WaitingStatus("Waiting for peer data to be updated")
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,6 @@ class RedisK8sCharm(CharmBase):
 
         Updates the Pebble layer if needed.
         """
-        self._initialize_directory_structure()
         self._store_certificates()
         self._update_layer()
 
@@ -329,6 +328,8 @@ class RedisK8sCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting for Pebble in workload container")
             return
 
+        self._initialize_directory_structure()
+
         if not self._valid_app_databag():
             self.unit.status = WaitingStatus("Waiting for peer data to be updated")
             return
@@ -351,10 +352,6 @@ class RedisK8sCharm(CharmBase):
     def _initialize_directory_structure(self) -> None:
         """Make sure all required directories for redis are available on startup."""
         container = self.unit.get_container("redis")
-
-        if not container.can_connect():
-            self.unit.status = WaitingStatus("Waiting for Pebble in workload container")
-            return
 
         if not container.exists(LOG_DIR):
             container.make_dir(

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ from ops.charm import ActionEvent, CharmBase, UpgradeCharmEvent
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, ModelError, Relation, WaitingStatus
-from ops.pebble import Layer, ExecError
+from ops.pebble import ExecError, Layer
 from redis import ConnectionError, Redis, TimeoutError
 from redis.exceptions import RedisError
 from tenacity import before_log, retry, stop_after_attempt, wait_fixed
@@ -349,7 +349,7 @@ class RedisK8sCharm(CharmBase):
         self.unit.status = ActiveStatus()
 
     def _initialize_directory_structure(self) -> None:
-        """Make sure all required directories for redis are available on startup"""
+        """Make sure all required directories for redis are available on startup."""
         container = self.unit.get_container("redis")
 
         if not container.can_connect():
@@ -375,9 +375,7 @@ class RedisK8sCharm(CharmBase):
             )
         else:
             try:
-                container.exec(
-                    ["chown", "-R", f"{REDIS_USER}:{REDIS_USER}", WORKING_DIR]
-                )
+                container.exec(["chown", "-R", f"{REDIS_USER}:{REDIS_USER}", WORKING_DIR])
             except ExecError as e:
                 logger.error(f"Exited with error {e}")
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -51,7 +51,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
-@pytest.mark.run(before="test_scale_down_departing_master")
+@pytest.mark.abort_on_fail
 async def test_scale_up_replication_after_failover(ops_test: OpsTest):
     """Trigger a failover and scale up the application, then test replication status."""
     unit_map = await get_unit_map(ops_test)
@@ -112,7 +112,7 @@ async def test_scale_up_replication_after_failover(ops_test: OpsTest):
         client.close()
 
 
-@pytest.mark.run(after="test_scale_up_replication_after_failover")
+@pytest.mark.abort_on_fail
 async def test_scale_down_departing_master(ops_test: OpsTest):
     """Failover to the last unit and scale down."""
     unit_map = await get_unit_map(ops_test)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -246,7 +246,8 @@ class TestCharm(TestCase):
         self.assertEqual(rel_data.get("hostname"), "10.2.1.5")
         self.assertEqual(rel_data.get("port"), "6379")
 
-    def test_pebble_layer_on_relation_created(self):
+    @mock.patch("charm.RedisK8sCharm._initialize_directory_structure")
+    def test_pebble_layer_on_relation_created(self, initialize_directory_structure):
         self.harness.set_leader(True)
 
         # Create a relation using 'redis' interface


### PR DESCRIPTION
## Issue
The fix in https://github.com/canonical/redis-k8s-operator/pull/91 for issue https://github.com/canonical/redis-k8s-operator/issues/90 did not solve the problem, as the Juju-created storage volume is obviously mounted on top of the existing directory on the image.

## Solution
To make sure all required directories have all required permissions, no matter the file system defaults of the cloud it is deployed to, we will initialize the directory structure on startup and create the directories with the required permissions within the container.