### PR TITLE
[DPE-5200] add leader info to relation data

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,20 +12,12 @@ tags:
   - kubernetes
   - redis
 summary: >
-  Redis is an open source (BSD licensed), in-memory data structure store, used
-  as a database, cache, and message broker. Redis provides data structures
-  such as strings, hashes, lists, sets, sorted sets with range queries,
-  bitmaps, hyperloglogs, geospatial indexes, and streams. Redis has built-in
-  replication, Lua scripting, LRU eviction, transactions, and different levels
-  of on-disk persistence, and provides high availability via Redis Sentinel and
-  automatic partitioning with Redis Cluster.
-
-  This charm supports Redis in Kubernetes environments, using k8s services
-  for load balancing. This supports a simple Redis topology. Although multiple
-  units are allowed, replication and clustering are not supported for the moment.
+  This charm supports Redis in Kubernetes environments, using k8s services for load
+  balancing. This supports a simple Redis topology, but replication and clustering
+  are not supported for the moment.
 maintainers:
-  - Eduardo Mucelli R. Oliveira <eduardo.mucelli@canonical.com>
-  - Raul Zamora Martinez <raul.zamora@canonical.com>
+  - Rene Radoi <rene.radoi@canonical.com>
+  - Smail Kourta <smail.kourta@canonical.com>
 
 provides:
   redis:

--- a/src/charm.py
+++ b/src/charm.py
@@ -309,10 +309,7 @@ class RedisK8sCharm(CharmBase):
             return
 
         self._peers.data[self.app]["enable-password"] = "false"
-
-        logger.info(f"relation data before: {event.relation.data}")
         event.relation.data[self.app][LEADER_HOST_KEY] = self.current_master
-        logger.info(f"relation data after: {event.relation.data}")
 
         self._update_layer()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -671,6 +671,10 @@ class RedisK8sCharm(CharmBase):
         logger.info(f"Unit {self.unit.name} updating master info to {info['ip']}")
         self._peers.data[self.app][LEADER_HOST_KEY] = info["ip"]
 
+        if relations := self.model.relations[REDIS_REL_NAME]:
+            for relation in relations:
+                relation.data[self.app][LEADER_HOST_KEY] = info["ip"]
+
     def _sentinel_failover(self, departing_unit_name: str) -> None:
         """Try to failover the current master.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -311,8 +311,7 @@ class RedisK8sCharm(CharmBase):
         self._peers.data[self.app]["enable-password"] = "false"
 
         logger.info(f"relation data before: {event.relation.data}")
-        info = self.sentinel.get_master_info()
-        event.relation.data[self.app][LEADER_HOST_KEY] = info["ip"]
+        event.relation.data[self.app][LEADER_HOST_KEY] = self.current_master
         logger.info(f"relation data after: {event.relation.data}")
 
         self._update_layer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -310,10 +310,10 @@ class RedisK8sCharm(CharmBase):
 
         self._peers.data[self.app]["enable-password"] = "false"
 
-        logger.info(f"relation data: {event.relation.data}")
+        logger.info(f"relation data before: {event.relation.data}")
         info = self.sentinel.get_master_info()
         event.relation.data[self.app][LEADER_HOST_KEY] = info["ip"]
-        logger.info(f"relation data: {event.relation.data}")
+        logger.info(f"relation data after: {event.relation.data}")
 
         self._update_layer()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -241,10 +241,12 @@ class TestCharm(TestCase):
         self.harness.add_relation_unit(rel_id, "wordpress/0")
         # When
         self.harness._emit_relation_changed(rel_id, "wordpress/0")
-        rel_data = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        rel_data_unit = self.harness.get_relation_data(rel_id, self.harness.charm.unit.name)
+        rel_data_app = self.harness.get_relation_data(rel_id, self.harness.charm.app.name)
         # Then
-        self.assertEqual(rel_data.get("hostname"), "10.2.1.5")
-        self.assertEqual(rel_data.get("port"), "6379")
+        self.assertEqual(rel_data_unit.get("hostname"), "10.2.1.5")
+        self.assertEqual(rel_data_unit.get("port"), "6379")
+        self.assertEqual(rel_data_app.get("leader-host"), self.harness.charm.unit_pod_hostname)
 
     @mock.patch("charm.RedisK8sCharm._initialize_directory_structure")
     def test_pebble_layer_on_relation_created(self, initialize_directory_structure):


### PR DESCRIPTION
## Issue
With https://github.com/canonical/redis-k8s-operator/issues/95 the Discourse team requests to have the Redis Sentinel leader information in the relation data.

## Solution
On updates to the Sentinel leader and when a new relation to redis is created, add the leader information to the relation data of all related applications.

## Note
It also fixes an issue with `metadata.yaml`, which caused builds to fail: With a recent `charmcraft` update, the summary in `metadata.yaml` must not be longer than 200 chars anymore.