### PR TITLE
only set LEADER_HOST_KEY in redis-relation data if available

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -309,7 +309,8 @@ class RedisK8sCharm(CharmBase):
             return
 
         self._peers.data[self.app]["enable-password"] = "false"
-        event.relation.data[self.app][LEADER_HOST_KEY] = self.current_master
+        if self.current_master:
+            event.relation.data[self.app][LEADER_HOST_KEY] = self.current_master
 
         self._update_layer()
 


### PR DESCRIPTION
## Issue
https://github.com/canonical/redis-k8s-operator/issues/97

If the `redis` relation is created before the leader was elected, it may happen that the Sentinel-leader of redis is not known yet. In this cases setting the relation data will fail because the value is `None` still.

## Solution
Check if the data is already available before writing it to the relation data.