### PR TITLE
Adjust sentinel config directory permission to proactively prepare for pebble v1.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.50"
+          bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -107,7 +107,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.50"
+          bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -146,7 +146,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.50"
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.43"
+          bootstrap-options: "--agent-version 2.9.50"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -107,7 +107,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.43"
+          bootstrap-options: "--agent-version 2.9.50"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -146,7 +146,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.50"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/src/sentinel.py
+++ b/src/sentinel.py
@@ -134,7 +134,7 @@ class Sentinel(Object):
             container.make_dir(
                 CONFIG_DIR,
                 make_parents=True,
-                permissions=0o770,
+                permissions=0o750,
                 user="redis",
                 group="redis",
             )

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju==2.9.42.4
+    juju==2.9.49.0
     pytest-operator
     pytest-order
     lightkube==0.13.0


### PR DESCRIPTION
## Issue
Juju 3.6 will upgrade from pebble v1.10.2 to v1.15.0 which includes the following PR: https://github.com/canonical/pebble/pull/423

TLDR; pebble did not account for umask previous to this PR. so if one uses `pebble mkdir` with permissions `770` or `777`, umask will de-escalate privileges to `755`. however, with this PR, the permissions for a newly created directory will be exactly what one specifies

## Solution
Since sentinel config directory (created with `770`) is actually being de-escalated to `750`, change the permissions to it explicitly to avoid surprises when upgrading to juju 3.6