### PR TITLE
chore(lib): Updated url with the leader host

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.43"
+          bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
@@ -107,7 +107,7 @@ jobs:
           provider: microk8s
           channel: "1.28-strict/stable"
           juju-channel: 2.9/stable
-          bootstrap-options: "--agent-version 2.9.43"
+          bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -39,7 +39,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +102,12 @@ class RedisRequires(Object):
         if not relation_data:
             return None
         redis_host = relation_data.get("hostname")
+        relation = self.model.get_relation(self.relation_name)
+        relation_app_data = relation.data.get(relation.app)
+        try:
+            redis_host = relation_app_data.get("leader-host", redis_host)
+        except KeyError:
+            pass
         redis_port = relation_data.get("port")
         return f"redis://{redis_host}:{redis_port}"
 

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -86,7 +86,9 @@ class RedisRequires(Object):
             Dict: dict containing the app data.
         """
         relation = self.model.get_relation(self.relation_name)
-        return relation.data.get(relation.app)
+        if not relation:
+            return None
+        return relation.data[relation.app]
 
     @property
     def relation_data(self) -> Optional[Dict[str, str]]:
@@ -109,13 +111,16 @@ class RedisRequires(Object):
             str: the Redis URL.
         """
         relation_data = self.relation_data
+        app_data = self.app_data
         if not relation_data:
             return None
         redis_host = relation_data.get("hostname")
-        try:
-            redis_host = self.app_data.get("leader-host", redis_host)
-        except KeyError:
-            pass
+
+        if app_data:
+            try:
+                redis_host = self.app_data.get("leader-host", redis_host)
+            except KeyError:
+                pass
         redis_port = relation_data.get("port")
         return f"redis://{redis_host}:{redis_port}"
 

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -110,13 +110,12 @@ class RedisRequires(Object):
         Returns:
             str: the Redis URL.
         """
-        relation_data = self.relation_data
-        app_data = self.app_data
-        if not relation_data:
+        if not (relation_data := self.relation_data):
             return None
+            
         redis_host = relation_data.get("hostname")
 
-        if app_data:
+        if app_data := self.app_data:
             try:
                 redis_host = self.app_data.get("leader-host", redis_host)
             except KeyError:

--- a/lib/charms/redis_k8s/v0/redis.py
+++ b/lib/charms/redis_k8s/v0/redis.py
@@ -79,6 +79,16 @@ class RedisRequires(Object):
         self.charm.on.redis_relation_updated.emit()
 
     @property
+    def app_data(self) -> Optional[Dict[str, str]]:
+        """Retrieve the app data.
+
+        Returns:
+            Dict: dict containing the app data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return relation.data.get(relation.app)
+
+    @property
     def relation_data(self) -> Optional[Dict[str, str]]:
         """Retrieve the relation data.
 
@@ -102,10 +112,8 @@ class RedisRequires(Object):
         if not relation_data:
             return None
         redis_host = relation_data.get("hostname")
-        relation = self.model.get_relation(self.relation_name)
-        relation_app_data = relation.data.get(relation.app)
         try:
-            redis_host = relation_app_data.get("leader-host", redis_host)
+            redis_host = self.app_data.get("leader-host", redis_host)
         except KeyError:
             pass
         redis_port = relation_data.get("port")

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju==2.9.42.4
+    juju==2.9.49.0
     pytest-operator
     pytest-order
     lightkube==0.13.0


### PR DESCRIPTION
## Issue

Since [DPE-5200] add leader info to relation data [PR](https://github.com/canonical/redis-k8s-operator/pull/96) we need to update a lot of our(IS DevOps) charms to use the `leader-host`. We also use the `.url` property but since it uses the unit ip we have to construct it in the charm. 
## Solution
Constructing the `.url` property in the library instead of changing multiple number of charms.

[DPE-5200]: https://warthogs.atlassian.net/browse/DPE-5200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ