### PR TITLE
Pin websockets because of breaking changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,9 @@ deps =
     pytest-operator
     pytest-order
     lightkube==0.13.0
+    # pin websockets to <14.0 because of breaking changes in this version
+    # see also: https://github.com/juju/python-libjuju/issues/1184
+    websockets<14.0
     -r {tox_root}/requirements.txt
 commands =
     pytest -vv --tb native --log-cli-level=INFO {[vars]tests_path}/integration/{env:TEST_FILE} -s {posargs}


### PR DESCRIPTION
## Issue
The newest major release of the websockets library - version 14.0 which was released on Saturday - is not compatible with python-libjuju and results in errors being thrown when using python-libjuju in our integration tests: https://github.com/canonical/redis-k8s-operator/actions/runs/11774109412/job/32792173912

See also: https://github.com/juju/python-libjuju/issues/1184

## Solution
Pin websockets dependency.