### PR TITLE
fix issue #103

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,7 @@ jobs:
         tox-environments:
           - integration-charm
           - integration-password
-          # Skipping until issues in `discourse-k8s-operator` are resolved. Issue:
-          # "https://github.com/canonical/discourse-k8s-operator/issues/268"
-          # - integration-redis-relation
+          - integration-redis-relation
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v23.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v23.0.1
 
   integration-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms.yaml@v29.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v29.0.0
 
   integration-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v23.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms.yaml@v29.0.0
 
   integration-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v7
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v23.0.0
 
   integration-test:
     strategy:
@@ -68,7 +68,7 @@ jobs:
           juju-channel: 2.9/stable
           bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.artifact-name }}
       - name: Select tests
@@ -107,7 +107,7 @@ jobs:
           juju-channel: 2.9/stable
           bootstrap-options: "--agent-version 2.9.49"
       - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.artifact-name }}
       - name: Select tests
@@ -146,7 +146,7 @@ jobs:
           juju-channel: 2.9/stable
           bootstrap-options: "--agent-version 2.9.29"
       - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.artifact-name }}
       - name: Select tests

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,13 +2,8 @@
 # See LICENSE file for licensing details.
 
 type: charm
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "22.04"
-    run-on:
-      - name: "ubuntu"
-        channel: "22.04"
+platforms:
+  ubuntu@22.04:amd64:
 parts:
   charm:
     charm-python-packages: [setuptools]

--- a/src/charm.py
+++ b/src/charm.py
@@ -578,8 +578,11 @@ class RedisK8sCharm(CharmBase):
         Returns:
             String with the password
         """
-        data = self._peers.data[self.app]
-        return data.get(SENTINEL_PASSWORD_KEY)
+        try:
+            data = self._peers.data[self.app]
+            return data.get(SENTINEL_PASSWORD_KEY)
+        except AttributeError as e:
+            logger.error(f"Error getting peer databag: {e}")
 
     def _store_certificates(self) -> None:
         """Copy the TLS certificates to the redis container."""


### PR DESCRIPTION
## Issue
`update-status` event can stuck the charm if the peer relation has been removed, see https://github.com/canonical/redis-k8s-operator/issues/103

## Solution
add error handling to `get_sentinel_password()` to avoid the charm to be stuck unrecoverable failure.