### PR TITLE
update lightkube dependency for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     juju==2.9.49.0
     pytest-operator
     pytest-order
-    lightkube==0.13.0
+    lightkube==0.17.0
     # pin websockets to <14.0 because of breaking changes in this version
     # see also: https://github.com/juju/python-libjuju/issues/1184
     websockets<14.0


### PR DESCRIPTION
## Issue
Integration tests fail because of an issue in lightkube v0.13.0: https://github.com/gtsystem/lightkube/issues/78

## Solution
update lightkube for integration tests to 0.17.0