### PR TITLE
Fix integration test for postgresql deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, jammy, large]
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -93,7 +93,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, jammy, large]
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -132,7 +132,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, jammy, large]
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -67,7 +67,8 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 application_name=POSTGRESQL_APP_NAME,
                 channel="14/stable",
                 series="jammy",
-                trust=True,
+                trust=True,,
+                config={"profile": "testing"},
             ),
         )
         await ops_test.model.wait_for_idle(

--- a/tests/integration/test_redis_relation.py
+++ b/tests/integration/test_redis_relation.py
@@ -67,7 +67,7 @@ async def test_build_and_deploy(ops_test: OpsTest, num_units: int):
                 application_name=POSTGRESQL_APP_NAME,
                 channel="14/stable",
                 series="jammy",
-                trust=True,,
+                trust=True,
                 config={"profile": "testing"},
             ),
         )


### PR DESCRIPTION
## Issue
integration tests with postgresql fail with the error: `<10% file space available on pgdata volume`.

## Solution
- set config option for `profile=testing` in postgresql deployment
- run integration tests on self-hosted Github runners