### PR TITLE
Enable TLS on the sentinel when enable-tls is true

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -125,6 +125,7 @@ class RedisK8sCharm(CharmBase):
         will trigger this event.
         """
         self._store_certificates()
+        self.sentinel._store_certificates()
 
         # NOTE: This is the case of a single unit deployment. If that's the case, the charm
         # doesn't need to check for failovers or figure out who the master is.

--- a/templates/sentinel.conf.j2
+++ b/templates/sentinel.conf.j2
@@ -1,4 +1,15 @@
+{% if enable_tls %}
+port 0
+tls-port {{ sentinel_port }}
+tls-cert-file "{{ storage_path }}/redis.crt"
+tls-key-file "{{ storage_path }}/redis.key"
+tls-ca-cert-file "{{ storage_path }}/ca.crt"
+tls-auth-clients optional
+tls-replication yes
+{% else %}
 port {{ sentinel_port }}
+{% endif %}
+
 sentinel monitor {{ master_name }} {{ redis_master }} {{ redis_port }} {{ quorum }}
 sentinel down-after-milliseconds {{ master_name }} 5000
 sentinel failover-timeout {{ master_name }} 30000

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -90,9 +90,9 @@ class TestCharm(TestCase):
         self.harness.charm.on.update_status.emit()
         found_plan = self.harness.get_container_pebble_plan("redis").to_dict()
         extra_flags = [
-            f"--requirepass {self.harness.charm._get_password()}",
+            f"--requirepass {self.harness.charm.get_password()}",
             "--bind 0.0.0.0",
-            f"--masterauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm.get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             "--logfile /var/log/redis/redis-server.log",
             "--appendonly yes",
@@ -116,7 +116,7 @@ class TestCharm(TestCase):
                     "group": "redis",
                     "startup": "enabled",
                     "environment": {
-                        "REDIS_PASSWORD": self.harness.charm._get_password(),
+                        "REDIS_PASSWORD": self.harness.charm.get_password(),
                     },
                 },
             },
@@ -137,9 +137,9 @@ class TestCharm(TestCase):
         self.harness.charm.on.update_status.emit()
         found_plan = self.harness.get_container_pebble_plan("redis").to_dict()
         extra_flags = [
-            f"--requirepass {self.harness.charm._get_password()}",
+            f"--requirepass {self.harness.charm.get_password()}",
             "--bind 0.0.0.0",
-            f"--masterauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm.get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             "--logfile /var/log/redis/redis-server.log",
             "--appendonly yes",
@@ -163,7 +163,7 @@ class TestCharm(TestCase):
                     "group": "redis",
                     "startup": "enabled",
                     "environment": {
-                        "REDIS_PASSWORD": self.harness.charm._get_password(),
+                        "REDIS_PASSWORD": self.harness.charm.get_password(),
                     },
                 },
             },
@@ -217,18 +217,18 @@ class TestCharm(TestCase):
     @mock.patch.object(RedisK8sCharm, "_is_failover_finished")
     def test_password_on_leader_elected(self, _):
         # Assert that there is no password in the peer relation.
-        self.assertFalse(self.harness.charm._get_password())
+        self.assertFalse(self.harness.charm.get_password())
 
         # Check that a new password was generated on leader election.
         self.harness.set_leader()
-        admin_password = self.harness.charm._get_password()
+        admin_password = self.harness.charm.get_password()
         self.assertTrue(admin_password)
 
         # Trigger a new leader election and check that the password is still the same.
         self.harness.set_leader(False)
         self.harness.set_leader()
         self.assertEqual(
-            self.harness.charm._get_password(),
+            self.harness.charm.get_password(),
             admin_password,
         )
 
@@ -286,7 +286,7 @@ class TestCharm(TestCase):
                     "group": "redis",
                     "startup": "enabled",
                     "environment": {
-                        "REDIS_PASSWORD": self.harness.charm._get_password(),
+                        "REDIS_PASSWORD": self.harness.charm.get_password(),
                     },
                 },
             },
@@ -296,14 +296,14 @@ class TestCharm(TestCase):
     @mock.patch("charm.RedisK8sCharm._store_certificates")
     def test_attach_resource(self, _store_certificates):
         # Check that there are no resources initially
-        self.assertEqual(self.harness.charm._certificates, [None, None, None])
+        self.assertEqual(self.harness.charm.certificates, [None, None, None])
 
         self.harness.add_resource("cert-file", "")
         self.harness.add_resource("key-file", "")
         self.harness.add_resource("ca-cert-file", "")
 
         # After adding them, check that the property returns paths for the three of them
-        self.assertTrue(None not in self.harness.charm._certificates)
+        self.assertTrue(None not in self.harness.charm.certificates)
 
         self.harness.set_leader(True)
         self.harness.charm.on.upgrade_charm.emit()
@@ -334,9 +334,9 @@ class TestCharm(TestCase):
 
         found_plan = self.harness.get_container_pebble_plan("redis").to_dict()
         extra_flags = [
-            f"--requirepass {self.harness.charm._get_password()}",
+            f"--requirepass {self.harness.charm.get_password()}",
             "--bind 0.0.0.0",
-            f"--masterauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm.get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             "--logfile /var/log/redis/redis-server.log",
             "--appendonly yes",
@@ -366,7 +366,7 @@ class TestCharm(TestCase):
                     "group": "redis",
                     "startup": "enabled",
                     "environment": {
-                        "REDIS_PASSWORD": self.harness.charm._get_password(),
+                        "REDIS_PASSWORD": self.harness.charm.get_password(),
                     },
                 },
             },
@@ -413,8 +413,8 @@ class TestCharm(TestCase):
         # Custom responses to Redis `execute_command` call
         def my_side_effect(value: str):
             mapping = {
-                f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL MASTER {self.harness.charm._name}": [
+                f"SENTINEL CKQUORUM {self.harness.charm.name}": "OK",
+                f"SENTINEL MASTER {self.harness.charm.name}": [
                     "ip",
                     APPLICATION_DATA["leader-host"],
                     "flags",
@@ -436,9 +436,9 @@ class TestCharm(TestCase):
         leader_hostname = APPLICATION_DATA["leader-host"]
         redis_port = 6379
         extra_flags = [
-            f"--requirepass {self.harness.charm._get_password()}",
+            f"--requirepass {self.harness.charm.get_password()}",
             "--bind 0.0.0.0",
-            f"--masterauth {self.harness.charm._get_password()}",
+            f"--masterauth {self.harness.charm.get_password()}",
             f"--replica-announce-ip {self.harness.charm.unit_pod_hostname}",
             "--logfile /var/log/redis/redis-server.log",
             "--appendonly yes",
@@ -463,7 +463,7 @@ class TestCharm(TestCase):
                     "group": "redis",
                     "startup": "enabled",
                     "environment": {
-                        "REDIS_PASSWORD": self.harness.charm._get_password(),
+                        "REDIS_PASSWORD": self.harness.charm.get_password(),
                     },
                 },
             },
@@ -478,8 +478,8 @@ class TestCharm(TestCase):
         # Custom responses to Redis `execute_command` call
         def my_side_effect(value: str):
             mapping = {
-                f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL MASTER {self.harness.charm._name}": [
+                f"SENTINEL CKQUORUM {self.harness.charm.name}": "OK",
+                f"SENTINEL MASTER {self.harness.charm.name}": [
                     "ip",
                     "different-leader",
                     "flags",
@@ -520,8 +520,8 @@ class TestCharm(TestCase):
         # Custom responses to Redis `execute_command` call
         def my_side_effect(value: str):
             mapping = {
-                f"SENTINEL CKQUORUM {self.harness.charm._name}": "OK",
-                f"SENTINEL MASTER {self.harness.charm._name}": [
+                f"SENTINEL CKQUORUM {self.harness.charm.name}": "OK",
+                f"SENTINEL MASTER {self.harness.charm.name}": [
                     "ip",
                     self.harness.charm._k8s_hostname("redis-k8s/1"),
                     "flags",


### PR DESCRIPTION
This fixes #111.

I took the approach of minimal impact on the charm itself, trying to follow as much as possible the existing practices and layout. IOW, I just made the certificate storage in `sentinel.py` mimic what `charm.py` already did for the main container.

I see the practice of reading "private" attributes starting with `_attr` from the other class is widespread, and I just followed that to reduce duplication.